### PR TITLE
Fix module path for go install compatibility

### DIFF
--- a/cmd/bv/main.go
+++ b/cmd/bv/main.go
@@ -9,13 +9,13 @@ import (
 	"strings"
 	"time"
 
-	"beads_viewer/pkg/analysis"
-	"beads_viewer/pkg/export"
-	"beads_viewer/pkg/loader"
-	"beads_viewer/pkg/model"
-	"beads_viewer/pkg/recipe"
-	"beads_viewer/pkg/ui"
-	"beads_viewer/pkg/version"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/analysis"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/export"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/loader"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/model"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/recipe"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/ui"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/version"
 
 	tea "github.com/charmbracelet/bubbletea"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,20 +1,21 @@
-module beads_viewer
+module github.com/Dicklesworthstone/beads_viewer
 
 // Keep this in sync with CI (see .github/workflows/ci.yml) and the minimum
 // version available in common dev environments.
 go 1.25
 
 require (
+	github.com/atotto/clipboard v0.1.4
 	github.com/charmbracelet/bubbles v0.21.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/glamour v0.10.0
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
 	gonum.org/v1/gonum v0.16.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
 	github.com/alecthomas/chroma/v2 v2.14.0 // indirect
-	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
@@ -43,5 +44,4 @@ require (
 	golang.org/x/sys v0.36.0 // indirect
 	golang.org/x/term v0.31.0 // indirect
 	golang.org/x/text v0.24.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -88,6 +88,7 @@ golang.org/x/text v0.24.0 h1:dd5Bzh4yt5KYA8f9CJHCP4FB4D51c2c6JvN37xJJkJ0=
 golang.org/x/text v0.24.0/go.mod h1:L8rBsPeo2pSS+xqN0d5u2ikmjtmoJbDBT1b7nHvFCdU=
 gonum.org/v1/gonum v0.16.0 h1:5+ul4Swaf3ESvrOnidPp4GZbzf0mxVQpDCYUQE7OJfk=
 gonum.org/v1/gonum v0.16.0/go.mod h1:fef3am4MQ93R2HHpKnLk4/Tbh/s0+wqD5nfa6Pnwy4E=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/analysis/diff.go
+++ b/pkg/analysis/diff.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 	"time"
 
-	"beads_viewer/pkg/model"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/model"
 )
 
 // Snapshot represents the state of issues at a point in time

--- a/pkg/analysis/diff_extended_test.go
+++ b/pkg/analysis/diff_extended_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"beads_viewer/pkg/model"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/model"
 )
 
 // TestDiff_TextFieldChanges tests detection of changes in text fields

--- a/pkg/analysis/diff_test.go
+++ b/pkg/analysis/diff_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"beads_viewer/pkg/model"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/model"
 )
 
 func TestNewSnapshot(t *testing.T) {

--- a/pkg/analysis/graph.go
+++ b/pkg/analysis/graph.go
@@ -4,7 +4,7 @@ import (
 	"math"
 	"time"
 
-	"beads_viewer/pkg/model"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/model"
 
 	"gonum.org/v1/gonum/graph"
 	"gonum.org/v1/gonum/graph/network"

--- a/pkg/analysis/graph_test.go
+++ b/pkg/analysis/graph_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"beads_viewer/pkg/analysis"
-	"beads_viewer/pkg/model"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/analysis"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/model"
 )
 
 // Helper to extract IDs from issues and sort them for comparison

--- a/pkg/analysis/insights_test.go
+++ b/pkg/analysis/insights_test.go
@@ -3,7 +3,7 @@ package analysis
 import (
 	"testing"
 
-	"beads_viewer/pkg/model"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/model"
 )
 
 // ============================================================================

--- a/pkg/analysis/plan.go
+++ b/pkg/analysis/plan.go
@@ -3,7 +3,7 @@ package analysis
 import (
 	"sort"
 
-	"beads_viewer/pkg/model"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/model"
 )
 
 // PlanItem represents a single actionable item in the execution plan

--- a/pkg/analysis/plan_extended_test.go
+++ b/pkg/analysis/plan_extended_test.go
@@ -3,8 +3,8 @@ package analysis_test
 import (
 	"testing"
 
-	"beads_viewer/pkg/analysis"
-	"beads_viewer/pkg/model"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/analysis"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/model"
 )
 
 // TestPlan_DiamondDependency tests a diamond graph structure

--- a/pkg/analysis/plan_test.go
+++ b/pkg/analysis/plan_test.go
@@ -3,8 +3,8 @@ package analysis_test
 import (
 	"testing"
 
-	"beads_viewer/pkg/analysis"
-	"beads_viewer/pkg/model"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/analysis"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/model"
 )
 
 func TestGetExecutionPlanEmpty(t *testing.T) {

--- a/pkg/analysis/priority.go
+++ b/pkg/analysis/priority.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 	"time"
 
-	"beads_viewer/pkg/model"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/model"
 )
 
 // ImpactScore represents the composite priority score for an issue

--- a/pkg/analysis/priority_test.go
+++ b/pkg/analysis/priority_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"beads_viewer/pkg/analysis"
-	"beads_viewer/pkg/model"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/analysis"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/model"
 )
 
 func TestComputeImpactScoresEmpty(t *testing.T) {

--- a/pkg/analysis/real_data_test.go
+++ b/pkg/analysis/real_data_test.go
@@ -8,8 +8,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"beads_viewer/pkg/analysis"
-	"beads_viewer/pkg/model"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/analysis"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/model"
 )
 
 // Helper to parse JSONL directly

--- a/pkg/analysis/sample_integration_test.go
+++ b/pkg/analysis/sample_integration_test.go
@@ -5,8 +5,8 @@ import (
 	"slices"
 	"testing"
 
-	"beads_viewer/pkg/loader"
-	"beads_viewer/pkg/model"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/loader"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/model"
 )
 
 // loadSampleIssues loads the shared fixture used for integration-style tests.

--- a/pkg/export/markdown.go
+++ b/pkg/export/markdown.go
@@ -9,7 +9,7 @@ import (
 	"time"
 	"unicode"
 
-	"beads_viewer/pkg/model"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/model"
 )
 
 // sanitizeMermaidID ensures an ID is valid for Mermaid diagrams.

--- a/pkg/export/markdown_test.go
+++ b/pkg/export/markdown_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"beads_viewer/pkg/model"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/model"
 )
 
 // ============================================================================

--- a/pkg/loader/git.go
+++ b/pkg/loader/git.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"time"
 
-	"beads_viewer/pkg/model"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/model"
 )
 
 // GitLoader loads beads from git history

--- a/pkg/loader/loader.go
+++ b/pkg/loader/loader.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"beads_viewer/pkg/model"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/model"
 )
 
 // FindJSONLPath locates the beads JSONL file in the given directory.

--- a/pkg/loader/loader_test.go
+++ b/pkg/loader/loader_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	"beads_viewer/pkg/loader"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/loader"
 )
 
 func TestLoadRealIssues(t *testing.T) {

--- a/pkg/loader/real_data_test.go
+++ b/pkg/loader/real_data_test.go
@@ -4,7 +4,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"beads_viewer/pkg/loader"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/loader"
 )
 
 func TestLoadRealIssuesBenchmark(t *testing.T) {

--- a/pkg/loader/robustness_test.go
+++ b/pkg/loader/robustness_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	"beads_viewer/pkg/loader"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/loader"
 )
 
 func TestLoadIssuesRobustness(t *testing.T) {

--- a/pkg/loader/synthetic_test.go
+++ b/pkg/loader/synthetic_test.go
@@ -3,7 +3,7 @@ package loader_test
 import (
 	"testing"
 
-	"beads_viewer/pkg/loader"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/loader"
 )
 
 func TestLoadSyntheticComplex(t *testing.T) {

--- a/pkg/recipe/loader_test.go
+++ b/pkg/recipe/loader_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"beads_viewer/pkg/recipe"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/recipe"
 )
 
 func TestLoaderBuiltinRecipes(t *testing.T) {

--- a/pkg/recipe/types_test.go
+++ b/pkg/recipe/types_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"beads_viewer/pkg/recipe"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/recipe"
 )
 
 func TestParseRelativeTimeDays(t *testing.T) {

--- a/pkg/ui/actionable.go
+++ b/pkg/ui/actionable.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"beads_viewer/pkg/analysis"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/analysis"
 
 	"github.com/charmbracelet/lipgloss"
 )

--- a/pkg/ui/actionable_test.go
+++ b/pkg/ui/actionable_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"beads_viewer/pkg/analysis"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/analysis"
 
 	"github.com/charmbracelet/lipgloss"
 )

--- a/pkg/ui/board.go
+++ b/pkg/ui/board.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 	"strings"
 
-	"beads_viewer/pkg/model"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/model"
 
 	"github.com/charmbracelet/lipgloss"
 )

--- a/pkg/ui/board_test.go
+++ b/pkg/ui/board_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"beads_viewer/pkg/model"
-	"beads_viewer/pkg/ui"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/model"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/ui"
 
 	"github.com/charmbracelet/lipgloss"
 )

--- a/pkg/ui/delegate.go
+++ b/pkg/ui/delegate.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"strings"
 
-	"beads_viewer/pkg/analysis"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/analysis"
 
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"

--- a/pkg/ui/graph.go
+++ b/pkg/ui/graph.go
@@ -5,8 +5,8 @@ import (
 	"sort"
 	"strings"
 
-	"beads_viewer/pkg/analysis"
-	"beads_viewer/pkg/model"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/analysis"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/model"
 
 	"github.com/charmbracelet/lipgloss"
 )

--- a/pkg/ui/graph_test.go
+++ b/pkg/ui/graph_test.go
@@ -3,9 +3,9 @@ package ui_test
 import (
 	"testing"
 
-	"beads_viewer/pkg/analysis"
-	"beads_viewer/pkg/model"
-	"beads_viewer/pkg/ui"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/analysis"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/model"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/ui"
 )
 
 // TestGraphModelEmpty verifies behavior with no issues

--- a/pkg/ui/helpers.go
+++ b/pkg/ui/helpers.go
@@ -6,7 +6,7 @@ import (
 	"time"
 	"unicode/utf8"
 
-	"beads_viewer/pkg/model"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/model"
 )
 
 // FormatTimeRel returns a relative time string (e.g., "2h ago", "3d ago")

--- a/pkg/ui/helpers_test.go
+++ b/pkg/ui/helpers_test.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"testing"
 
-	"beads_viewer/pkg/model"
-	"beads_viewer/pkg/ui"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/model"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/ui"
 )
 
 // TestTruncateRunesHelper tests UTF-8 safe truncation

--- a/pkg/ui/insights.go
+++ b/pkg/ui/insights.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	"beads_viewer/pkg/analysis"
-	"beads_viewer/pkg/model"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/analysis"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/model"
 
 	"github.com/charmbracelet/lipgloss"
 )

--- a/pkg/ui/insights_test.go
+++ b/pkg/ui/insights_test.go
@@ -3,9 +3,9 @@ package ui_test
 import (
 	"testing"
 
-	"beads_viewer/pkg/analysis"
-	"beads_viewer/pkg/model"
-	"beads_viewer/pkg/ui"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/analysis"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/model"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/ui"
 )
 
 // createTestInsights creates a test Insights struct with sample data

--- a/pkg/ui/item.go
+++ b/pkg/ui/item.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"beads_viewer/pkg/model"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/model"
 )
 
 // DiffStatus represents the diff state of an issue in time-travel mode

--- a/pkg/ui/logic_test.go
+++ b/pkg/ui/logic_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"beads_viewer/pkg/model"
-	"beads_viewer/pkg/recipe"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/model"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/recipe"
 )
 
 // White-box testing of UI model logic

--- a/pkg/ui/model.go
+++ b/pkg/ui/model.go
@@ -10,12 +10,12 @@ import (
 	"strings"
 	"time"
 
-	"beads_viewer/pkg/analysis"
-	"beads_viewer/pkg/export"
-	"beads_viewer/pkg/loader"
-	"beads_viewer/pkg/model"
-	"beads_viewer/pkg/recipe"
-	"beads_viewer/pkg/updater"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/analysis"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/export"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/loader"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/model"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/recipe"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/updater"
 
 	"github.com/atotto/clipboard"
 	"github.com/charmbracelet/bubbles/list"

--- a/pkg/ui/model_test.go
+++ b/pkg/ui/model_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"beads_viewer/pkg/model"
-	"beads_viewer/pkg/ui"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/model"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/ui"
 )
 
 func TestModelFiltering(t *testing.T) {

--- a/pkg/ui/recipe_picker.go
+++ b/pkg/ui/recipe_picker.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"beads_viewer/pkg/recipe"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/recipe"
 
 	"github.com/charmbracelet/lipgloss"
 )

--- a/pkg/ui/recipe_picker_test.go
+++ b/pkg/ui/recipe_picker_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"beads_viewer/pkg/recipe"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/recipe"
 
 	"github.com/charmbracelet/lipgloss"
 )

--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"beads_viewer/pkg/version"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/version"
 )
 
 type Release struct {

--- a/pkg/workspace/types_test.go
+++ b/pkg/workspace/types_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"beads_viewer/pkg/workspace"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/workspace"
 )
 
 func TestRepoConfigGetPrefix(t *testing.T) {


### PR DESCRIPTION
Change module path from `beads_viewer` to `github.com/Dicklesworthstone/beads_viewer` to enable `go install` and `go run` from the module path:

    go run github.com/Dicklesworthstone/beads_viewer/cmd/bv@latest