### PR TITLE
fix(docs): correct malformed install URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 ### ⚡ Quick Install
 
 ```bash
-curl -fsSL "https://raw.githubusercontent.com/Dicklesworthstone/github.com/Dicklesworthstone/beads_viewer/main/install.sh?$(date +%s)" | bash
+curl -fsSL "https://raw.githubusercontent.com/Dicklesworthstone/beads_viewer/main/install.sh?$(date +%s)" | bash
 ```
 
 ---
@@ -1378,7 +1378,7 @@ A: `bv` is data-agnostic. The Beads data schema supports an `external_ref` field
 The fastest way to get started. Detects your OS and architecture automatically.
 
 ```bash
-curl -fsSL "https://raw.githubusercontent.com/Dicklesworthstone/github.com/Dicklesworthstone/beads_viewer/main/install.sh?$(date +%s)" | bash
+curl -fsSL "https://raw.githubusercontent.com/Dicklesworthstone/beads_viewer/main/install.sh?$(date +%s)" | bash
 ```
 
 ### Build from Source


### PR DESCRIPTION
## Summary
- Fixed duplicated path segment in curl install command that was causing 404 errors
- The URL had `github.com/Dicklesworthstone/` incorrectly inserted in the path

**Before:**
```
raw.githubusercontent.com/Dicklesworthstone/github.com/Dicklesworthstone/beads_viewer/main/install.sh
```

**After:**
```
raw.githubusercontent.com/Dicklesworthstone/beads_viewer/main/install.sh
```

## Test plan
- [ ] Verify the curl command works: `curl -fsSL "https://raw.githubusercontent.com/Dicklesworthstone/beads_viewer/main/install.sh" | bash`

🤖 Generated with [Claude Code](https://claude.com/claude-code)