### PR TITLE
FIX Quick Install Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 ### ⚡ Quick Install
 
 ```bash
-curl -fsSL "https://raw.githubusercontent.com/Dicklesworthstone/github.com/Dicklesworthstone/beads_viewer/main/install.sh?$(date +%s)" | bash
+curl -fsSL "https://raw.githubusercontent.com/Dicklesworthstone/beads_viewer/main/install.sh?$(date +%s)" | bash
 ```
 
 ---


### PR DESCRIPTION
The install command in the README pointed at a nonexistent raw github url. it embedded the full github.com/... path inside the raw.githubusercontent.com layout, which caused all install attempts to hit a 404.