### PR TITLE
feat: add --profile-tui-startup for comprehensive TUI startup profiling

### DIFF
--- a/cmd/bv/main.go
+++ b/cmd/bv/main.go
@@ -42,7 +42,8 @@ func main() {
 	asOf := flag.String("as-of", "", "View state at point in time (commit SHA, branch, tag, or date)")
 	forceFullAnalysis := flag.Bool("force-full-analysis", false, "Compute all metrics regardless of graph size (may be slow for large graphs)")
 	profileStartup := flag.Bool("profile-startup", false, "Output detailed startup timing profile for diagnostics")
-	profileJSON := flag.Bool("profile-json", false, "Output profile in JSON format (use with --profile-startup)")
+	profileTUIStartup := flag.Bool("profile-tui-startup", false, "Output comprehensive TUI startup profile (includes analysis + UI components)")
+	profileJSON := flag.Bool("profile-json", false, "Output profile in JSON format (use with --profile-startup or --profile-tui-startup)")
 	noHooks := flag.Bool("no-hooks", false, "Skip running hooks during export")
 	workspaceConfig := flag.String("workspace", "", "Load issues from workspace config file (.bv/workspace.yaml)")
 	repoFilter := flag.String("repo", "", "Filter issues by repository prefix (e.g., 'api-' or 'api')")
@@ -145,6 +146,12 @@ func main() {
 		fmt.Println("      Outputs detailed startup timing profile for diagnostics.")
 		fmt.Println("      Shows Phase 1 (blocking) and Phase 2 (async) breakdown.")
 		fmt.Println("      Provides recommendations based on timing analysis.")
+		fmt.Println("      Use with --profile-json for machine-readable output.")
+		fmt.Println("")
+		fmt.Println("  --profile-tui-startup")
+		fmt.Println("      Comprehensive TUI startup profile including UI component initialization.")
+		fmt.Println("      Shows all phases: data loading, graph analysis, and TUI components.")
+		fmt.Println("      Use this to diagnose slow startup when --profile-startup shows fast times.")
 		fmt.Println("      Use with --profile-json for machine-readable output.")
 		fmt.Println("")
 		fmt.Println("  --workspace CONFIG")
@@ -289,6 +296,12 @@ func main() {
 	// Handle --profile-startup
 	if *profileStartup {
 		runProfileStartup(issues, loadDuration, *profileJSON, *forceFullAnalysis)
+		os.Exit(0)
+	}
+
+	// Handle --profile-tui-startup
+	if *profileTUIStartup {
+		runProfileTUIStartup(issues, loadDuration, activeRecipe, beadsPath, *profileJSON)
 		os.Exit(0)
 	}
 
@@ -1145,6 +1158,146 @@ func runProfileStartup(issues []model.Issue, loadDuration time.Duration, jsonOut
 		// Human-readable output
 		printProfileReport(profile, loadDuration, totalWithLoad)
 	}
+}
+
+// runProfileTUIStartup runs profiled TUI startup and outputs comprehensive results
+func runProfileTUIStartup(issues []model.Issue, loadDuration time.Duration, activeRecipe *recipe.Recipe, beadsPath string, jsonOutput bool) {
+	// Create model with profiling
+	_, tuiProfile := ui.NewModelWithProfile(issues, activeRecipe, beadsPath)
+
+	// Set the load duration
+	tuiProfile.SetLoadDuration(loadDuration)
+	tuiProfile.ComputeTotals()
+
+	if jsonOutput {
+		// JSON output
+		output := struct {
+			GeneratedAt string             `json:"generated_at"`
+			DataPath    string             `json:"data_path"`
+			Profile     *ui.TUIStartupProfile `json:"profile"`
+		}{
+			GeneratedAt: time.Now().UTC().Format(time.RFC3339),
+			DataPath:    ".beads/beads.jsonl",
+			Profile:     tuiProfile,
+		}
+
+		encoder := json.NewEncoder(os.Stdout)
+		encoder.SetIndent("", "  ")
+		if err := encoder.Encode(output); err != nil {
+			fmt.Fprintf(os.Stderr, "Error encoding profile: %v\n", err)
+			os.Exit(1)
+		}
+	} else {
+		// Human-readable output
+		printTUIProfileReport(tuiProfile)
+	}
+}
+
+// printTUIProfileReport outputs a human-readable TUI startup profile
+func printTUIProfileReport(profile *ui.TUIStartupProfile) {
+	fmt.Println("TUI Startup Profile")
+	fmt.Println("===================")
+	fmt.Printf("Data: %d issues, %d dependencies\n\n", profile.IssueCount, profile.DependencyCount)
+
+	// Phase 1 - Data Loading
+	fmt.Println("Phase 1 - Data Loading:")
+	fmt.Printf("  Load JSONL:        %v\n\n", formatDuration(profile.LoadJSONL))
+
+	// Phase 2 - Analysis
+	if profile.Analysis != nil {
+		fmt.Println("Phase 2 - Graph Analysis:")
+		fmt.Printf("  Build graph:       %v\n", formatDuration(profile.Analysis.BuildGraph))
+		fmt.Printf("  Degree:            %v\n", formatDuration(profile.Analysis.Degree))
+		fmt.Printf("  TopoSort:          %v\n", formatDuration(profile.Analysis.TopoSort))
+		printMetricLine("PageRank", profile.Analysis.PageRank, profile.Analysis.PageRankTO, profile.Analysis.Config.ComputePageRank)
+		printMetricLine("Betweenness", profile.Analysis.Betweenness, profile.Analysis.BetweennessTO, profile.Analysis.Config.ComputeBetweenness)
+		printMetricLine("Eigenvector", profile.Analysis.Eigenvector, false, profile.Analysis.Config.ComputeEigenvector)
+		printMetricLine("HITS", profile.Analysis.HITS, profile.Analysis.HITSTO, profile.Analysis.Config.ComputeHITS)
+		printMetricLine("Critical Path", profile.Analysis.CriticalPath, false, profile.Analysis.Config.ComputeCriticalPath)
+		printCyclesLine(profile.Analysis)
+		fmt.Printf("  Total Analysis:    %v\n\n", formatDuration(profile.Analysis.Total))
+	}
+
+	// Phase 3 - TUI Components
+	fmt.Println("Phase 3 - TUI Components:")
+	fmt.Printf("  Sort issues:       %v\n", formatDuration(profile.SortIssues))
+	fmt.Printf("  Build lookup:      %v\n", formatDuration(profile.BuildLookup))
+	fmt.Printf("  Compute stats:     %v\n", formatDuration(profile.ComputeStats))
+	fmt.Printf("  Theme init:        %v\n", formatDuration(profile.ThemeInit))
+	fmt.Printf("  List setup:        %v\n", formatDuration(profile.ListSetup))
+	fmt.Printf("  Glamour renderer:  %v\n", formatDuration(profile.GlamourInit))
+	fmt.Printf("  Board model:       %v\n", formatDuration(profile.BoardInit))
+	fmt.Printf("  Insights panel:    %v\n", formatDuration(profile.InsightsInit))
+	fmt.Printf("  Graph view:        %v\n", formatDuration(profile.GraphViewInit))
+	fmt.Printf("  Recipe loader:     %v\n", formatDuration(profile.RecipeLoader))
+	fmt.Printf("  Recipe picker:     %v\n", formatDuration(profile.RecipePicker))
+	fmt.Printf("  Text input:        %v\n", formatDuration(profile.TextInputInit))
+	fmt.Printf("  File watcher:      %v\n", formatDuration(profile.FileWatcherInit))
+	fmt.Printf("  Total TUI:         %v\n\n", formatDuration(profile.TUIComponentsTotal))
+
+	// Total
+	fmt.Printf("NewModel total:      %v\n", formatDuration(profile.NewModelTotal))
+	fmt.Printf("Total startup:       %v\n\n", formatDuration(profile.TotalStartup))
+
+	// Recommendations
+	recommendations := generateTUIProfileRecommendations(profile)
+	if len(recommendations) > 0 {
+		fmt.Println("Recommendations:")
+		for _, rec := range recommendations {
+			fmt.Printf("  %s\n", rec)
+		}
+	}
+}
+
+// generateTUIProfileRecommendations generates actionable recommendations based on TUI profile
+func generateTUIProfileRecommendations(profile *ui.TUIStartupProfile) []string {
+	var recs []string
+
+	// Check overall startup time
+	if profile.TotalStartup < 500*time.Millisecond {
+		recs = append(recs, "✓ Startup within acceptable range (<500ms)")
+	} else if profile.TotalStartup < 1*time.Second {
+		recs = append(recs, "✓ Startup acceptable (<1s)")
+	} else if profile.TotalStartup < 2*time.Second {
+		recs = append(recs, "⚠ Startup is slow (1-2s)")
+	} else {
+		recs = append(recs, "⚠ Startup is very slow (>2s) - see breakdown above")
+	}
+
+	// Find the slowest TUI component
+	type component struct {
+		name     string
+		duration time.Duration
+	}
+	components := []component{
+		{"Glamour renderer", profile.GlamourInit},
+		{"File watcher", profile.FileWatcherInit},
+		{"Recipe loader", profile.RecipeLoader},
+		{"Board model", profile.BoardInit},
+		{"Insights panel", profile.InsightsInit},
+		{"Graph view", profile.GraphViewInit},
+		{"List setup", profile.ListSetup},
+		{"Theme init", profile.ThemeInit},
+	}
+
+	// Find slowest
+	var slowest component
+	for _, c := range components {
+		if c.duration > slowest.duration {
+			slowest = c
+		}
+	}
+
+	if slowest.duration > 100*time.Millisecond {
+		recs = append(recs, fmt.Sprintf("⚠ Slowest component: %s (%v)", slowest.name, formatDuration(slowest.duration)))
+	}
+
+	// Check if analysis is dominating
+	if profile.Analysis != nil && profile.Analysis.Total > profile.TUIComponentsTotal {
+		recs = append(recs, "ℹ Analysis phase is taking longer than TUI initialization - use --profile-startup for details")
+	}
+
+	return recs
 }
 
 // printProfileReport outputs a human-readable startup profile

--- a/pkg/ui/model.go
+++ b/pkg/ui/model.go
@@ -388,6 +388,253 @@ func NewModel(issues []model.Issue, activeRecipe *recipe.Recipe, beadsPath strin
 	}
 }
 
+// NewModelWithProfile creates a new Model with detailed timing profile.
+// Used by --profile-tui-startup to diagnose slow startup.
+func NewModelWithProfile(issues []model.Issue, activeRecipe *recipe.Recipe, beadsPath string) (Model, *TUIStartupProfile) {
+	profile := &TUIStartupProfile{
+		IssueCount: len(issues),
+	}
+	totalStart := time.Now()
+
+	// Count dependencies
+	for _, issue := range issues {
+		profile.DependencyCount += len(issue.Dependencies)
+	}
+
+	// Graph Analysis - run synchronously with profiling for accurate timing
+	t := time.Now()
+	analyzer := analysis.NewAnalyzer(issues)
+
+	// Estimate edge count for config selection
+	edgeCount := 0
+	for _, issue := range issues {
+		edgeCount += len(issue.Dependencies)
+	}
+	config := analysis.ConfigForSize(len(issues), edgeCount)
+	graphStats, analysisProfile := analyzer.AnalyzeWithProfile(config)
+	profile.Analysis = analysisProfile
+
+	// Sort issues
+	t = time.Now()
+	if activeRecipe != nil && activeRecipe.Sort.Field != "" {
+		r := activeRecipe
+		descending := r.Sort.Direction == "desc"
+
+		sort.Slice(issues, func(i, j int) bool {
+			less := false
+			switch r.Sort.Field {
+			case "priority":
+				less = issues[i].Priority < issues[j].Priority
+			case "created", "created_at":
+				less = issues[i].CreatedAt.Before(issues[j].CreatedAt)
+			case "updated", "updated_at":
+				less = issues[i].UpdatedAt.Before(issues[j].UpdatedAt)
+			case "impact":
+				less = graphStats.GetCriticalPathScore(issues[i].ID) < graphStats.GetCriticalPathScore(issues[j].ID)
+			case "pagerank":
+				less = graphStats.GetPageRankScore(issues[i].ID) < graphStats.GetPageRankScore(issues[j].ID)
+			default:
+				less = issues[i].Priority < issues[j].Priority
+			}
+			if descending {
+				return !less
+			}
+			return less
+		})
+	} else {
+		sort.Slice(issues, func(i, j int) bool {
+			iClosed := issues[i].Status == model.StatusClosed
+			jClosed := issues[j].Status == model.StatusClosed
+			if iClosed != jClosed {
+				return !iClosed
+			}
+			if issues[i].Priority != issues[j].Priority {
+				return issues[i].Priority < issues[j].Priority
+			}
+			return issues[i].CreatedAt.After(issues[j].CreatedAt)
+		})
+	}
+	profile.SortIssues = time.Since(t)
+
+	// Build lookup map and list items
+	t = time.Now()
+	issueMap := make(map[string]*model.Issue, len(issues))
+	items := make([]list.Item, len(issues))
+	for i := range issues {
+		issueMap[issues[i].ID] = &issues[i]
+		items[i] = IssueItem{
+			Issue:      issues[i],
+			GraphScore: graphStats.GetPageRankScore(issues[i].ID),
+			Impact:     graphStats.GetCriticalPathScore(issues[i].ID),
+			RepoPrefix: ExtractRepoPrefix(issues[i].ID),
+		}
+	}
+	profile.BuildLookup = time.Since(t)
+
+	// Compute stats
+	t = time.Now()
+	cOpen, cReady, cBlocked, cClosed := 0, 0, 0, 0
+	for i := range issues {
+		issue := &issues[i]
+		if issue.Status == model.StatusClosed {
+			cClosed++
+			continue
+		}
+		cOpen++
+		if issue.Status == model.StatusBlocked {
+			cBlocked++
+			continue
+		}
+		isBlocked := false
+		for _, dep := range issue.Dependencies {
+			if dep.Type != model.DepBlocks {
+				continue
+			}
+			if blocker, exists := issueMap[dep.DependsOnID]; exists && blocker.Status != model.StatusClosed {
+				isBlocked = true
+				break
+			}
+		}
+		if !isBlocked {
+			cReady++
+		}
+	}
+	profile.ComputeStats = time.Since(t)
+
+	// Theme
+	t = time.Now()
+	theme := DefaultTheme(lipgloss.NewRenderer(os.Stdout))
+	profile.ThemeInit = time.Since(t)
+
+	// List setup
+	t = time.Now()
+	delegate := IssueDelegate{Theme: theme, WorkspaceMode: false}
+	l := list.New(items, delegate, 0, 0)
+	l.Title = ""
+	l.SetShowTitle(false)
+	l.SetShowHelp(false)
+	l.SetShowStatusBar(false)
+	l.SetShowPagination(false)
+	l.SetFilteringEnabled(true)
+	l.DisableQuitKeybindings()
+	l.Styles.Title = lipgloss.NewStyle()
+	l.Styles.TitleBar = lipgloss.NewStyle()
+	l.Styles.FilterPrompt = lipgloss.NewStyle().Foreground(theme.Primary)
+	l.Styles.FilterCursor = lipgloss.NewStyle().Foreground(theme.Primary)
+	l.Styles.StatusBar = lipgloss.NewStyle()
+	l.Styles.StatusEmpty = lipgloss.NewStyle()
+	l.Styles.StatusBarActiveFilter = lipgloss.NewStyle()
+	l.Styles.StatusBarFilterCount = lipgloss.NewStyle()
+	l.Styles.NoItems = lipgloss.NewStyle()
+	l.Styles.PaginationStyle = lipgloss.NewStyle()
+	l.Styles.HelpStyle = lipgloss.NewStyle()
+	profile.ListSetup = time.Since(t)
+
+	// Glamour markdown renderer
+	t = time.Now()
+	renderer, _ := glamour.NewTermRenderer(
+		glamour.WithAutoStyle(),
+		glamour.WithWordWrap(80),
+	)
+	profile.GlamourInit = time.Since(t)
+
+	// Initialize sub-components
+	t = time.Now()
+	board := NewBoardModel(issues, theme)
+	profile.BoardInit = time.Since(t)
+
+	t = time.Now()
+	ins := graphStats.GenerateInsights(len(issues))
+	insightsPanel := NewInsightsModel(ins, issueMap, theme)
+	profile.InsightsInit = time.Since(t)
+
+	t = time.Now()
+	graphView := NewGraphModel(issues, &ins, theme)
+	profile.GraphViewInit = time.Since(t)
+
+	priorityHints := make(map[string]*analysis.PriorityRecommendation)
+
+	// Initialize recipe loader
+	t = time.Now()
+	recipeLoader := recipe.NewLoader()
+	_ = recipeLoader.Load()
+	profile.RecipeLoader = time.Since(t)
+
+	t = time.Now()
+	recipePicker := NewRecipePickerModel(recipeLoader.List(), theme)
+	profile.RecipePicker = time.Since(t)
+
+	// Initialize time-travel input
+	t = time.Now()
+	ti := textinput.New()
+	ti.Placeholder = "HEAD~5, main, v1.0.0, 2024-01-01..."
+	ti.CharLimit = 100
+	ti.Width = 40
+	ti.Prompt = "⏱️  Revision: "
+	ti.PromptStyle = lipgloss.NewStyle().Foreground(theme.Primary).Bold(true)
+	ti.TextStyle = lipgloss.NewStyle().Foreground(theme.Base.GetForeground())
+	profile.TextInputInit = time.Since(t)
+
+	// Initialize file watcher for live reload
+	t = time.Now()
+	var fileWatcher *watcher.Watcher
+	var watcherErr error
+	if beadsPath != "" {
+		w, err := watcher.NewWatcher(beadsPath,
+			watcher.WithDebounceDuration(200*time.Millisecond),
+		)
+		if err != nil {
+			watcherErr = err
+		} else if err := w.Start(); err != nil {
+			watcherErr = err
+		} else {
+			fileWatcher = w
+		}
+	}
+	profile.FileWatcherInit = time.Since(t)
+
+	var initialStatus string
+	var initialStatusErr bool
+	if watcherErr != nil {
+		initialStatus = fmt.Sprintf("Live reload unavailable: %v", watcherErr)
+		initialStatusErr = true
+	}
+
+	profile.NewModelTotal = time.Since(totalStart)
+	profile.ComputeTotals()
+
+	m := Model{
+		issues:            issues,
+		issueMap:          issueMap,
+		analyzer:          analyzer,
+		analysis:          graphStats,
+		beadsPath:         beadsPath,
+		watcher:           fileWatcher,
+		list:              l,
+		renderer:          renderer,
+		board:             board,
+		graphView:         graphView,
+		insightsPanel:     insightsPanel,
+		theme:             theme,
+		currentFilter:     "all",
+		focused:           focusList,
+		countOpen:         cOpen,
+		countReady:        cReady,
+		countBlocked:      cBlocked,
+		countClosed:       cClosed,
+		priorityHints:     priorityHints,
+		showPriorityHints: false,
+		recipeLoader:      recipeLoader,
+		recipePicker:      recipePicker,
+		activeRecipe:      activeRecipe,
+		timeTravelInput:   ti,
+		statusMsg:         initialStatus,
+		statusIsError:     initialStatusErr,
+	}
+
+	return m, profile
+}
+
 func (m Model) Init() tea.Cmd {
 	cmds := []tea.Cmd{CheckUpdateCmd(), WaitForPhase2Cmd(m.analysis)}
 	if m.watcher != nil {

--- a/pkg/ui/profile.go
+++ b/pkg/ui/profile.go
@@ -1,0 +1,60 @@
+package ui
+
+import (
+	"time"
+
+	"github.com/Dicklesworthstone/beads_viewer/pkg/analysis"
+)
+
+// TUIStartupProfile captures detailed timing information for TUI initialization.
+// Use NewModelWithProfile to populate this structure.
+type TUIStartupProfile struct {
+	// Data characteristics
+	IssueCount      int `json:"issue_count"`
+	DependencyCount int `json:"dependency_count"`
+
+	// Phase 1 - Data Loading (captured externally)
+	LoadJSONL time.Duration `json:"load_jsonl"`
+
+	// Phase 2 - Analysis (from analysis.StartupProfile)
+	Analysis *analysis.StartupProfile `json:"analysis,omitempty"`
+
+	// Phase 3 - TUI Component Initialization
+	ThemeInit       time.Duration `json:"theme_init"`
+	ListSetup       time.Duration `json:"list_setup"`
+	GlamourInit     time.Duration `json:"glamour_init"`
+	BoardInit       time.Duration `json:"board_init"`
+	InsightsInit    time.Duration `json:"insights_init"`
+	GraphViewInit   time.Duration `json:"graph_view_init"`
+	RecipeLoader    time.Duration `json:"recipe_loader"`
+	RecipePicker    time.Duration `json:"recipe_picker"`
+	TextInputInit   time.Duration `json:"text_input_init"`
+	FileWatcherInit time.Duration `json:"file_watcher_init"`
+	SortIssues      time.Duration `json:"sort_issues"`
+	BuildLookup     time.Duration `json:"build_lookup"`
+	ComputeStats    time.Duration `json:"compute_stats"`
+
+	// Totals
+	TUIComponentsTotal time.Duration `json:"tui_components_total"`
+	NewModelTotal      time.Duration `json:"new_model_total"`
+	TotalStartup       time.Duration `json:"total_startup"`
+}
+
+// SetLoadDuration sets the JSONL load duration (captured before NewModel).
+func (p *TUIStartupProfile) SetLoadDuration(d time.Duration) {
+	p.LoadJSONL = d
+}
+
+// ComputeTotals calculates the total fields based on individual timings.
+func (p *TUIStartupProfile) ComputeTotals() {
+	p.TUIComponentsTotal = p.ThemeInit + p.ListSetup + p.GlamourInit +
+		p.BoardInit + p.InsightsInit + p.GraphViewInit +
+		p.RecipeLoader + p.RecipePicker + p.TextInputInit +
+		p.FileWatcherInit
+
+	if p.Analysis != nil {
+		p.TotalStartup = p.LoadJSONL + p.Analysis.Total + p.TUIComponentsTotal
+	} else {
+		p.TotalStartup = p.LoadJSONL + p.NewModelTotal
+	}
+}


### PR DESCRIPTION
## Summary

Adds a new `--profile-tui-startup` flag that provides comprehensive TUI startup profiling, including all UI component initialization timing.

## Background

When investigating slow TUI startup, we found a discrepancy: `--profile-startup` showed analysis completing in ~3ms, but actual TUI startup took 5-10 seconds. The existing flag only profiled JSONL loading and graph analysis, missing the TUI component initialization phase entirely.

This new flag fills that gap by profiling the complete startup path.

## Technical Details

### New Files
- **pkg/ui/profile.go** - `TUIStartupProfile` struct with timing fields for each component

### Modified Files
- **pkg/ui/model.go** - Added `NewModelWithProfile()` that wraps component initialization with timing
- **cmd/bv/main.go** - Flag definition, handler, human-readable and JSON output formatting

### What Gets Profiled

**Phase 1 - Data Loading:**
- JSONL file loading

**Phase 2 - Graph Analysis:**
- Build graph, Degree, TopoSort
- PageRank, Betweenness, Eigenvector, HITS
- Critical Path, Cycle detection

**Phase 3 - TUI Components:**
- Sort issues, Build lookup, Compute stats
- Theme init, List setup, Glamour renderer
- Board model, Insights panel, Graph view
- Recipe loader, Recipe picker
- Text input, File watcher

### Example Output

```
TUI Startup Profile
===================
Data: 72 issues, 51 dependencies

Phase 1 - Data Loading:
  Load JSONL:             3ms

Phase 2 - Graph Analysis:
  Build graph:         0.00ms
  Degree:              0.04ms
  ...
  Total Analysis:         1ms

Phase 3 - TUI Components:
  Sort issues:         0.01ms
  Theme init:          0.02ms
  Glamour renderer:    0.05ms
  ...
  Total TUI:              1ms

NewModel total:           3ms
Total startup:            6ms

Recommendations:
  ✓ Startup within acceptable range (<500ms)
```

## Test Plan
- [x] Build succeeds
- [x] All existing tests pass
- [x] Human-readable output works
- [x] JSON output works (--profile-json)
- [x] Help text displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)