### PR TITLE
feat(loader): add BEADS_DIR environment variable support

### DIFF
--- a/cmd/bv/main.go
+++ b/cmd/bv/main.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -275,9 +274,9 @@ func main() {
 			fmt.Fprintln(os.Stderr, "Make sure you are in a project initialized with 'bd init'.")
 			os.Exit(1)
 		}
-		// Get beads file path for live reload
-		cwd, _ := os.Getwd()
-		beadsPath, _ = loader.FindJSONLPath(filepath.Join(cwd, ".beads"))
+		// Get beads file path for live reload (respects BEADS_DIR)
+		beadsDir, _ := loader.GetBeadsDir("")
+		beadsPath, _ = loader.FindJSONLPath(beadsDir)
 	}
 	loadDuration := time.Since(loadStart)
 

--- a/pkg/loader/loader.go
+++ b/pkg/loader/loader.go
@@ -79,18 +79,36 @@ func FindJSONLPath(beadsDir string) (string, error) {
 	return filepath.Join(beadsDir, candidates[0]), nil
 }
 
-// LoadIssues reads issues from the .beads directory in the given repository path.
-// Automatically finds the correct JSONL file (beads.jsonl preferred, issues.jsonl fallback).
-func LoadIssues(repoPath string) ([]model.Issue, error) {
+// GetBeadsDir returns the beads directory path, respecting the BEADS_DIR environment variable.
+// If BEADS_DIR is set, it is used directly.
+// Otherwise, falls back to .beads in the given repoPath (or cwd if repoPath is empty).
+func GetBeadsDir(repoPath string) (string, error) {
+	// Check BEADS_DIR environment variable first
+	if envDir := os.Getenv("BEADS_DIR"); envDir != "" {
+		return envDir, nil
+	}
+
+	// Fall back to .beads in repo path
 	if repoPath == "" {
 		var err error
 		repoPath, err = os.Getwd()
 		if err != nil {
-			return nil, fmt.Errorf("failed to get current working directory: %w", err)
+			return "", fmt.Errorf("failed to get current working directory: %w", err)
 		}
 	}
 
-	beadsDir := filepath.Join(repoPath, ".beads")
+	return filepath.Join(repoPath, ".beads"), nil
+}
+
+// LoadIssues reads issues from the .beads directory in the given repository path.
+// Automatically finds the correct JSONL file (beads.jsonl preferred, issues.jsonl fallback).
+// Respects the BEADS_DIR environment variable if set.
+func LoadIssues(repoPath string) ([]model.Issue, error) {
+	beadsDir, err := GetBeadsDir(repoPath)
+	if err != nil {
+		return nil, err
+	}
+
 	jsonlPath, err := FindJSONLPath(beadsDir)
 	if err != nil {
 		return nil, err

--- a/pkg/loader/loader_test.go
+++ b/pkg/loader/loader_test.go
@@ -206,6 +206,71 @@ func TestFindJSONLPath_FollowsSymlink(t *testing.T) {
 }
 
 // =============================================================================
+// GetBeadsDir Tests
+// =============================================================================
+
+func TestGetBeadsDir_UsesEnvVar(t *testing.T) {
+	// Set BEADS_DIR environment variable
+	customDir := "/custom/beads/path"
+	os.Setenv("BEADS_DIR", customDir)
+	defer os.Unsetenv("BEADS_DIR")
+
+	dir, err := loader.GetBeadsDir("")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if dir != customDir {
+		t.Errorf("Expected %s, got %s", customDir, dir)
+	}
+}
+
+func TestGetBeadsDir_EnvVarOverridesRepoPath(t *testing.T) {
+	// Set BEADS_DIR environment variable
+	customDir := "/custom/beads/path"
+	os.Setenv("BEADS_DIR", customDir)
+	defer os.Unsetenv("BEADS_DIR")
+
+	// Even with a repo path, BEADS_DIR should take precedence
+	dir, err := loader.GetBeadsDir("/some/repo/path")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if dir != customDir {
+		t.Errorf("Expected BEADS_DIR (%s) to override repo path, got %s", customDir, dir)
+	}
+}
+
+func TestGetBeadsDir_FallsBackToRepoPath(t *testing.T) {
+	// Ensure BEADS_DIR is not set
+	os.Unsetenv("BEADS_DIR")
+
+	repoPath := "/my/repo"
+	dir, err := loader.GetBeadsDir(repoPath)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	expected := filepath.Join(repoPath, ".beads")
+	if dir != expected {
+		t.Errorf("Expected %s, got %s", expected, dir)
+	}
+}
+
+func TestGetBeadsDir_FallsBackToCwd(t *testing.T) {
+	// Ensure BEADS_DIR is not set
+	os.Unsetenv("BEADS_DIR")
+
+	dir, err := loader.GetBeadsDir("")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	cwd, _ := os.Getwd()
+	expected := filepath.Join(cwd, ".beads")
+	if dir != expected {
+		t.Errorf("Expected %s, got %s", expected, dir)
+	}
+}
+
+// =============================================================================
 // LoadIssues Tests
 // =============================================================================
 
@@ -215,6 +280,28 @@ func TestLoadIssues_NonExistentBeadsDir(t *testing.T) {
 	_, err := loader.LoadIssues(dir)
 	if err == nil {
 		t.Fatal("Expected error for non-existent .beads directory")
+	}
+}
+
+func TestLoadIssues_RespectsBeadsDirEnvVar(t *testing.T) {
+	// Create a custom beads directory (not inside .beads)
+	customDir := t.TempDir()
+	os.WriteFile(filepath.Join(customDir, "beads.jsonl"), []byte(`{"id":"env-1","title":"From Env","status":"open","issue_type":"task"}`+"\n"), 0644)
+
+	// Set BEADS_DIR to point to custom directory
+	os.Setenv("BEADS_DIR", customDir)
+	defer os.Unsetenv("BEADS_DIR")
+
+	// Call LoadIssues with empty path - it should use BEADS_DIR
+	issues, err := loader.LoadIssues("")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if len(issues) != 1 {
+		t.Fatalf("Expected 1 issue, got %d", len(issues))
+	}
+	if issues[0].ID != "env-1" {
+		t.Errorf("Expected ID 'env-1', got '%s'", issues[0].ID)
 	}
 }
 


### PR DESCRIPTION
Allow users to specify a custom beads directory location via the BEADS_DIR environment variable. When set, it overrides the default .beads directory lookup. This enables more flexible project layouts and cross-directory beads file access.