### PR TITLE
fix(ui): use configured beads path in openInEditor instead of hardcoded path

### DIFF
--- a/pkg/loader/loader.go
+++ b/pkg/loader/loader.go
@@ -49,11 +49,11 @@ func FindJSONLPath(beadsDir string) (string, error) {
 	}
 
 	// Priority order for beads files:
-	// 1. beads.jsonl (canonical)
-	// 2. beads.base.jsonl (bd's primary storage)
-	// 3. issues.jsonl (legacy)
+	// 1. issues.jsonl (canonical)
+	// 2. beads.jsonl
+	// 3. beads.base.jsonl (bd's primary storage)
 	// 4. First candidate
-	preferredNames := []string{"beads.jsonl", "beads.base.jsonl", "issues.jsonl"}
+	preferredNames := []string{"issues.jsonl", "beads.jsonl", "beads.base.jsonl"}
 
 	for _, preferred := range preferredNames {
 		for _, name := range candidates {
@@ -80,7 +80,7 @@ func FindJSONLPath(beadsDir string) (string, error) {
 }
 
 // LoadIssues reads issues from the .beads directory in the given repository path.
-// Automatically finds the correct JSONL file (beads.jsonl preferred, issues.jsonl fallback).
+// Automatically finds the correct JSONL file (issues.jsonl preferred, beads.jsonl fallback).
 func LoadIssues(repoPath string) ([]model.Issue, error) {
 	if repoPath == "" {
 		var err error

--- a/pkg/loader/loader_test.go
+++ b/pkg/loader/loader_test.go
@@ -48,7 +48,7 @@ func TestFindJSONLPath_NoJSONLFiles(t *testing.T) {
 	}
 }
 
-func TestFindJSONLPath_PrefersBeadsJSONL(t *testing.T) {
+func TestFindJSONLPath_PrefersIssuesJSONL(t *testing.T) {
 	dir := t.TempDir()
 	// Create multiple JSONL files
 	os.WriteFile(filepath.Join(dir, "issues.jsonl"), []byte(`{"id":"1"}`), 0644)
@@ -59,16 +59,30 @@ func TestFindJSONLPath_PrefersBeadsJSONL(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
+	if filepath.Base(path) != "issues.jsonl" {
+		t.Errorf("Expected issues.jsonl to be preferred, got: %s", path)
+	}
+}
+
+func TestFindJSONLPath_FallsBackToBeadsJSONL(t *testing.T) {
+	dir := t.TempDir()
+	// Create beads.jsonl and beads.base.jsonl (no issues.jsonl)
+	os.WriteFile(filepath.Join(dir, "beads.jsonl"), []byte(`{"id":"1"}`), 0644)
+	os.WriteFile(filepath.Join(dir, "beads.base.jsonl"), []byte(`{"id":"2"}`), 0644)
+
+	path, err := loader.FindJSONLPath(dir)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
 	if filepath.Base(path) != "beads.jsonl" {
-		t.Errorf("Expected beads.jsonl to be preferred, got: %s", path)
+		t.Errorf("Expected beads.jsonl, got: %s", path)
 	}
 }
 
 func TestFindJSONLPath_FallsBackToBeadsBase(t *testing.T) {
 	dir := t.TempDir()
-	// Create beads.base.jsonl and issues.jsonl (no beads.jsonl)
-	os.WriteFile(filepath.Join(dir, "issues.jsonl"), []byte(`{"id":"1"}`), 0644)
-	os.WriteFile(filepath.Join(dir, "beads.base.jsonl"), []byte(`{"id":"2"}`), 0644)
+	// Create only beads.base.jsonl
+	os.WriteFile(filepath.Join(dir, "beads.base.jsonl"), []byte(`{"id":"1"}`), 0644)
 
 	path, err := loader.FindJSONLPath(dir)
 	if err != nil {
@@ -76,20 +90,6 @@ func TestFindJSONLPath_FallsBackToBeadsBase(t *testing.T) {
 	}
 	if filepath.Base(path) != "beads.base.jsonl" {
 		t.Errorf("Expected beads.base.jsonl, got: %s", path)
-	}
-}
-
-func TestFindJSONLPath_FallsBackToIssues(t *testing.T) {
-	dir := t.TempDir()
-	// Create only issues.jsonl
-	os.WriteFile(filepath.Join(dir, "issues.jsonl"), []byte(`{"id":"1"}`), 0644)
-
-	path, err := loader.FindJSONLPath(dir)
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-	if filepath.Base(path) != "issues.jsonl" {
-		t.Errorf("Expected issues.jsonl, got: %s", path)
 	}
 }
 

--- a/pkg/ui/coverage_extra_test.go
+++ b/pkg/ui/coverage_extra_test.go
@@ -411,14 +411,15 @@ func TestOpenInEditorTerminalEditorGuard(t *testing.T) {
 	oldCwd, _ := os.Getwd()
 	defer os.Chdir(oldCwd)
 	_ = os.MkdirAll(filepath.Join(tmp, ".beads"), 0755)
-	_ = os.WriteFile(filepath.Join(tmp, ".beads", "beads.jsonl"), []byte("{}"), 0644)
+	beadsFile := filepath.Join(tmp, ".beads", "issues.jsonl")
+	_ = os.WriteFile(beadsFile, []byte("{}"), 0644)
 	_ = os.Chdir(tmp)
 
 	origEditor := os.Getenv("EDITOR")
 	defer os.Setenv("EDITOR", origEditor)
 	_ = os.Setenv("EDITOR", "vim") // triggers terminal-editor guard, no exec
 
-	m := NewModel(nil, nil, "")
+	m := NewModel(nil, nil, beadsFile)
 	m.openInEditor()
 	if !m.statusIsError || !strings.Contains(m.statusMsg, "terminal editor") {
 		t.Fatalf("expected terminal editor warning, got %q", m.statusMsg)
@@ -539,7 +540,7 @@ func TestOpenInEditorMissingAndGUI(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("openInEditor GUI path is unreliable on headless Windows CI")
 	}
-	// Missing beads file branch
+	// Empty beadsPath branch
 	tmp := t.TempDir()
 	origWD, _ := os.Getwd()
 	t.Cleanup(func() { _ = os.Chdir(origWD) })
@@ -547,19 +548,21 @@ func TestOpenInEditorMissingAndGUI(t *testing.T) {
 
 	m := NewModel([]model.Issue{{ID: "1", Title: "x", Status: model.StatusOpen}}, nil, "")
 	m.openInEditor()
-	if !m.statusIsError || !strings.Contains(m.statusMsg, "No .beads") {
+	if !m.statusIsError || !strings.Contains(m.statusMsg, "No beads file") {
 		t.Fatalf("expected missing beads error, got %q", m.statusMsg)
 	}
 
 	// Success branch with GUI-ish editor
 	beadsDir := filepath.Join(tmp, ".beads")
 	_ = os.Mkdir(beadsDir, 0o755)
-	_ = os.WriteFile(filepath.Join(beadsDir, "beads.jsonl"), []byte(`{}`), 0o644)
+	beadsFile := filepath.Join(beadsDir, "issues.jsonl")
+	_ = os.WriteFile(beadsFile, []byte(`{}`), 0o644)
 
 	origEditor := os.Getenv("EDITOR")
 	t.Cleanup(func() { _ = os.Setenv("EDITOR", origEditor) })
 	_ = os.Setenv("EDITOR", "true") // present on POSIX; not in terminal editor block
 
+	m = NewModel([]model.Issue{{ID: "1", Title: "x", Status: model.StatusOpen}}, nil, beadsFile)
 	m.openInEditor()
 	if m.statusIsError || !strings.Contains(m.statusMsg, "Opened in") {
 		t.Fatalf("expected success opening editor, got %q", m.statusMsg)

--- a/pkg/ui/model.go
+++ b/pkg/ui/model.go
@@ -2471,18 +2471,16 @@ func (m *Model) copyIssueToClipboard() {
 	m.statusIsError = false
 }
 
-// openInEditor opens the beads.jsonl file in the user's preferred editor
+// openInEditor opens the beads file in the user's preferred editor
 func (m *Model) openInEditor() {
-	cwd, err := os.Getwd()
-	if err != nil {
-		m.statusMsg = "❌ Cannot get working directory"
+	if m.beadsPath == "" {
+		m.statusMsg = "❌ No beads file configured"
 		m.statusIsError = true
 		return
 	}
 
-	beadsFile := filepath.Join(cwd, ".beads", "beads.jsonl")
-	if _, err := os.Stat(beadsFile); os.IsNotExist(err) {
-		m.statusMsg = "❌ No .beads/beads.jsonl file found"
+	if _, err := os.Stat(m.beadsPath); os.IsNotExist(err) {
+		m.statusMsg = fmt.Sprintf("❌ Beads file not found: %s", m.beadsPath)
 		m.statusIsError = true
 		return
 	}
@@ -2510,7 +2508,7 @@ func (m *Model) openInEditor() {
 		switch runtime.GOOS {
 		case "darwin":
 			// Use 'open' to launch default app for .jsonl files
-			cmd := exec.Command("open", "-t", beadsFile)
+			cmd := exec.Command("open", "-t", m.beadsPath)
 			if err := cmd.Start(); err == nil {
 				m.statusMsg = "📝 Opened in default text editor"
 				m.statusIsError = false
@@ -2536,8 +2534,8 @@ func (m *Model) openInEditor() {
 	}
 
 	// Launch GUI editor in background
-	cmd := exec.Command(editor, beadsFile)
-	err = cmd.Start()
+	cmd := exec.Command(editor, m.beadsPath)
+	err := cmd.Start()
 	if err != nil {
 		m.statusMsg = fmt.Sprintf("❌ Failed to open editor: %v", err)
 		m.statusIsError = true


### PR DESCRIPTION
The 'O' (edit) keybinding fails when the beads file isn't named exactly `beads.jsonl` because [`openInEditor()`](https://github.com/Dicklesworthstone/beads_viewer/blob/main/pkg/ui/model.go#L2474) hardcodes that path instead of using the `beadsPath` field already stored in the Model.

The beads project uses `issues.jsonl` as canonical, not `beads.jsonl`. This is documented in the [beads pre-commit hook](https://github.com/steveyegge/beads/blob/main/.beads-hooks/pre-commit#L38):

> Stage all tracked JSONL files (issues.jsonl is canonical, beads.jsonl for backward compat, deletions.jsonl for deletion propagation)

Also fixed the file priority order in `loader.FindJSONLPath()` to match beads upstream (issues.jsonl → beads.jsonl → beads.base.jsonl).