### PR TITLE
feat(multi-project): add support for viewing issues across multiple projects

### DIFF
--- a/pkg/config/projects.go
+++ b/pkg/config/projects.go
@@ -1,0 +1,154 @@
+// Package config provides user-level configuration for bv.
+package config
+
+import (
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ProjectsFileName is the name of the projects config file.
+const ProjectsFileName = "projects.yaml"
+
+// ProjectsConfig holds the user's saved project list.
+type ProjectsConfig struct {
+	// Projects is the list of saved projects.
+	Projects []ProjectEntry `yaml:"projects"`
+}
+
+// ProjectEntry represents a single project in the saved config.
+type ProjectEntry struct {
+	// Name is an optional display name for the project.
+	Name string `yaml:"name,omitempty"`
+	// Path is the absolute path to the project directory.
+	Path string `yaml:"path"`
+	// Enabled indicates whether this project should be loaded (default: true).
+	Enabled *bool `yaml:"enabled,omitempty"`
+}
+
+// IsEnabled returns whether the project is enabled.
+func (p *ProjectEntry) IsEnabled() bool {
+	if p.Enabled == nil {
+		return true
+	}
+	return *p.Enabled
+}
+
+// DefaultConfigDir returns the bv config directory.
+// Uses XDG_CONFIG_HOME if set, otherwise ~/.config/bv.
+func DefaultConfigDir() string {
+	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
+		return filepath.Join(xdg, "bv")
+	}
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".config", "bv")
+}
+
+// ProjectsConfigPath returns the full path to the projects config file.
+func ProjectsConfigPath() string {
+	return filepath.Join(DefaultConfigDir(), ProjectsFileName)
+}
+
+// LoadProjects loads the projects config from the default location.
+// Returns an empty config if the file doesn't exist.
+func LoadProjects() (*ProjectsConfig, error) {
+	return LoadProjectsFrom(ProjectsConfigPath())
+}
+
+// LoadProjectsFrom loads the projects config from a specific path.
+func LoadProjectsFrom(path string) (*ProjectsConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &ProjectsConfig{}, nil
+		}
+		return nil, err
+	}
+
+	var config ProjectsConfig
+	if err := yaml.Unmarshal(data, &config); err != nil {
+		return nil, err
+	}
+	return &config, nil
+}
+
+// SaveProjects saves the projects config to the default location.
+func SaveProjects(config *ProjectsConfig) error {
+	return SaveProjectsTo(config, ProjectsConfigPath())
+}
+
+// SaveProjectsTo saves the projects config to a specific path.
+func SaveProjectsTo(config *ProjectsConfig, path string) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+
+	data, err := yaml.Marshal(config)
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(path, data, 0644)
+}
+
+// ClearProjects removes the projects config file.
+func ClearProjects() error {
+	path := ProjectsConfigPath()
+	err := os.Remove(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	return err
+}
+
+// AddProject adds a project to the config if it doesn't already exist.
+// Returns true if the project was added, false if it already existed.
+func (c *ProjectsConfig) AddProject(path string) bool {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		absPath = path
+	}
+
+	// Check if already exists
+	for _, p := range c.Projects {
+		if p.Path == absPath {
+			return false
+		}
+	}
+
+	c.Projects = append(c.Projects, ProjectEntry{
+		Name: filepath.Base(absPath),
+		Path: absPath,
+	})
+	return true
+}
+
+// RemoveProject removes a project from the config by path.
+// Returns true if the project was removed, false if it wasn't found.
+func (c *ProjectsConfig) RemoveProject(path string) bool {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		absPath = path
+	}
+
+	for i, p := range c.Projects {
+		if p.Path == absPath {
+			c.Projects = append(c.Projects[:i], c.Projects[i+1:]...)
+			return true
+		}
+	}
+	return false
+}
+
+// EnabledPaths returns the paths of all enabled projects.
+func (c *ProjectsConfig) EnabledPaths() []string {
+	var paths []string
+	for _, p := range c.Projects {
+		if p.IsEnabled() {
+			paths = append(paths, p.Path)
+		}
+	}
+	return paths
+}

--- a/pkg/ui/project_manager.go
+++ b/pkg/ui/project_manager.go
@@ -1,0 +1,345 @@
+package ui
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// ProjectEntry represents a project in the project manager.
+type ProjectEntry struct {
+	Name       string // Display name
+	Path       string // Absolute path to project directory
+	Prefix     string // Namespace prefix (e.g., "api-")
+	IssueCount int    // Number of issues from this project
+	IsActive   bool   // Whether currently included in view
+}
+
+// ProjectManagerModel represents the project manager overlay.
+type ProjectManagerModel struct {
+	projects      []ProjectEntry
+	selectedIndex int
+	addMode       bool // True when entering a new path
+	pathInput     textinput.Model
+	width         int
+	height        int
+	theme         Theme
+	errorMsg      string
+}
+
+// NewProjectManagerModel creates a new project manager.
+func NewProjectManagerModel(theme Theme) ProjectManagerModel {
+	ti := textinput.New()
+	ti.Placeholder = "/path/to/project"
+	ti.CharLimit = 256
+	ti.Width = 50
+	ti.Prompt = "Path: "
+
+	return ProjectManagerModel{
+		projects:  []ProjectEntry{},
+		pathInput: ti,
+		theme:     theme,
+	}
+}
+
+// SetProjects sets the project list.
+func (m *ProjectManagerModel) SetProjects(projects []ProjectEntry) {
+	m.projects = projects
+	if m.selectedIndex >= len(projects) {
+		m.selectedIndex = len(projects) - 1
+	}
+	if m.selectedIndex < 0 {
+		m.selectedIndex = 0
+	}
+}
+
+// SetSize updates the overlay dimensions.
+func (m *ProjectManagerModel) SetSize(width, height int) {
+	m.width = width
+	m.height = height
+	// Resize text input
+	inputWidth := 50
+	if width < 70 {
+		inputWidth = width - 20
+	}
+	if inputWidth < 30 {
+		inputWidth = 30
+	}
+	m.pathInput.Width = inputWidth
+}
+
+// MoveUp moves selection up.
+func (m *ProjectManagerModel) MoveUp() {
+	if m.addMode {
+		return
+	}
+	if m.selectedIndex > 0 {
+		m.selectedIndex--
+	}
+}
+
+// MoveDown moves selection down.
+func (m *ProjectManagerModel) MoveDown() {
+	if m.addMode {
+		return
+	}
+	if m.selectedIndex < len(m.projects)-1 {
+		m.selectedIndex++
+	}
+}
+
+// ToggleActive toggles whether the selected project is active.
+func (m *ProjectManagerModel) ToggleActive() {
+	if m.addMode || len(m.projects) == 0 {
+		return
+	}
+	if m.selectedIndex >= 0 && m.selectedIndex < len(m.projects) {
+		m.projects[m.selectedIndex].IsActive = !m.projects[m.selectedIndex].IsActive
+	}
+}
+
+// EnterAddMode enters the mode for adding a new project path.
+func (m *ProjectManagerModel) EnterAddMode() {
+	m.addMode = true
+	m.pathInput.SetValue("")
+	m.pathInput.Focus()
+	m.errorMsg = ""
+}
+
+// ExitAddMode exits add mode without adding.
+func (m *ProjectManagerModel) ExitAddMode() {
+	m.addMode = false
+	m.pathInput.Blur()
+	m.errorMsg = ""
+}
+
+// IsAddMode returns whether we're in add mode.
+func (m *ProjectManagerModel) IsAddMode() bool {
+	return m.addMode
+}
+
+// GetInputValue returns the current path input value.
+func (m *ProjectManagerModel) GetInputValue() string {
+	return m.pathInput.Value()
+}
+
+// SetError sets an error message to display.
+func (m *ProjectManagerModel) SetError(msg string) {
+	m.errorMsg = msg
+}
+
+// ClearError clears the error message.
+func (m *ProjectManagerModel) ClearError() {
+	m.errorMsg = ""
+}
+
+// UpdateInput updates the text input with a key message.
+func (m *ProjectManagerModel) UpdateInput(msg interface{}) {
+	var cmd interface{}
+	m.pathInput, cmd = m.pathInput.Update(msg)
+	_ = cmd
+}
+
+// SelectedProject returns the currently selected project, or nil if none.
+func (m *ProjectManagerModel) SelectedProject() *ProjectEntry {
+	if len(m.projects) == 0 || m.selectedIndex < 0 || m.selectedIndex >= len(m.projects) {
+		return nil
+	}
+	return &m.projects[m.selectedIndex]
+}
+
+// RemoveSelected removes the currently selected project from the list.
+func (m *ProjectManagerModel) RemoveSelected() *ProjectEntry {
+	if len(m.projects) == 0 || m.selectedIndex < 0 || m.selectedIndex >= len(m.projects) {
+		return nil
+	}
+	removed := m.projects[m.selectedIndex]
+	m.projects = append(m.projects[:m.selectedIndex], m.projects[m.selectedIndex+1:]...)
+	if m.selectedIndex >= len(m.projects) && m.selectedIndex > 0 {
+		m.selectedIndex--
+	}
+	return &removed
+}
+
+// AddProject adds a new project entry to the list.
+func (m *ProjectManagerModel) AddProject(entry ProjectEntry) {
+	m.projects = append(m.projects, entry)
+}
+
+// ActiveProjects returns entries that are currently active.
+func (m *ProjectManagerModel) ActiveProjects() []ProjectEntry {
+	var active []ProjectEntry
+	for _, p := range m.projects {
+		if p.IsActive {
+			active = append(active, p)
+		}
+	}
+	return active
+}
+
+// AllProjects returns all project entries.
+func (m *ProjectManagerModel) AllProjects() []ProjectEntry {
+	return m.projects
+}
+
+// View renders the project manager overlay.
+func (m *ProjectManagerModel) View() string {
+	if m.width == 0 {
+		m.width = 80
+	}
+	if m.height == 0 {
+		m.height = 24
+	}
+
+	t := m.theme
+
+	// Calculate box dimensions
+	boxWidth := 70
+	if m.width < 80 {
+		boxWidth = m.width - 10
+	}
+	if boxWidth < 40 {
+		boxWidth = 40
+	}
+
+	var lines []string
+
+	// Title
+	titleStyle := t.Renderer.NewStyle().
+		Foreground(t.Primary).
+		Bold(true).
+		MarginBottom(1)
+	lines = append(lines, titleStyle.Render("Project Manager"))
+	lines = append(lines, "")
+
+	if m.addMode {
+		// Add mode view
+		addLabel := t.Renderer.NewStyle().Foreground(t.Secondary).Render("Add project path:")
+		lines = append(lines, addLabel)
+		lines = append(lines, m.pathInput.View())
+
+		if m.errorMsg != "" {
+			errorStyle := t.Renderer.NewStyle().Foreground(t.Blocked) // Use Blocked color for errors
+			lines = append(lines, errorStyle.Render(m.errorMsg))
+		}
+
+		lines = append(lines, "")
+		footerStyle := t.Renderer.NewStyle().
+			Foreground(t.Secondary).
+			Italic(true)
+		lines = append(lines, footerStyle.Render("enter: add • esc: cancel"))
+	} else {
+		// Project list view
+		if len(m.projects) == 0 {
+			emptyStyle := t.Renderer.NewStyle().Foreground(t.Secondary).Italic(true)
+			lines = append(lines, emptyStyle.Render("No projects loaded."))
+			lines = append(lines, emptyStyle.Render("Use 'a' to add a project."))
+		} else {
+			// Header
+			headerStyle := t.Renderer.NewStyle().Foreground(t.Secondary).Underline(true)
+			header := "  Name                 Path                              Issues"
+			lines = append(lines, headerStyle.Render(header))
+
+			// Project rows
+			for i, proj := range m.projects {
+				isCursor := i == m.selectedIndex
+
+				nameStyle := t.Renderer.NewStyle().Foreground(t.Base.GetForeground())
+				if isCursor {
+					nameStyle = nameStyle.Foreground(t.Primary).Bold(true)
+				}
+				if !proj.IsActive {
+					nameStyle = nameStyle.Foreground(t.Secondary)
+				}
+
+				cursor := "  "
+				if isCursor {
+					cursor = "▸ "
+				}
+
+				check := "[ ]"
+				if proj.IsActive {
+					check = "[x]"
+				}
+
+				// Truncate name and path for display
+				name := truncateString(proj.Name, 16)
+				path := truncatePathMiddle(proj.Path, 30)
+
+				line := cursor + check + " " + padRight(name, 16) + " " + padRight(path, 32) + " " + padLeftPM(fmt.Sprintf("%d", proj.IssueCount), 5)
+				lines = append(lines, nameStyle.Render(line))
+			}
+		}
+
+		lines = append(lines, "")
+		footerStyle := t.Renderer.NewStyle().
+			Foreground(t.Secondary).
+			Italic(true)
+		lines = append(lines, footerStyle.Render("j/k: navigate • space: toggle • a: add • d: remove • enter: apply • esc: cancel"))
+	}
+
+	content := strings.Join(lines, "\n")
+
+	boxStyle := t.Renderer.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(t.Primary).
+		Padding(1, 2).
+		Width(boxWidth)
+	box := boxStyle.Render(content)
+
+	return lipgloss.Place(
+		m.width,
+		m.height,
+		lipgloss.Center,
+		lipgloss.Center,
+		box,
+	)
+}
+
+// truncatePathMiddle truncates a path in the middle, preserving start and end.
+func truncatePathMiddle(path string, max int) string {
+	if len(path) <= max {
+		return path
+	}
+	if max <= 5 {
+		return path[:max]
+	}
+
+	// Show first part and last part
+	half := (max - 3) / 2
+	return path[:half] + "..." + path[len(path)-half:]
+}
+
+// padLeftPM pads a string to the left with spaces (project manager specific).
+func padLeftPM(s string, width int) string {
+	if len(s) >= width {
+		return s
+	}
+	return strings.Repeat(" ", width-len(s)) + s
+}
+
+// BuildProjectEntriesFromPaths creates ProjectEntry slice from paths and issue counts.
+func BuildProjectEntriesFromPaths(paths []string, prefixes []string, issueCounts map[string]int) []ProjectEntry {
+	var entries []ProjectEntry
+	for i, path := range paths {
+		var prefix string
+		if i < len(prefixes) {
+			prefix = prefixes[i]
+		}
+		count := 0
+		if issueCounts != nil {
+			count = issueCounts[prefix]
+		}
+		entries = append(entries, ProjectEntry{
+			Name:       filepath.Base(path),
+			Path:       path,
+			Prefix:     prefix,
+			IssueCount: count,
+			IsActive:   true,
+		})
+	}
+	return entries
+}

--- a/tests/e2e/multi_project_e2e_test.go
+++ b/tests/e2e/multi_project_e2e_test.go
@@ -1,0 +1,453 @@
+package main_test
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ============================================================================
+// E2E: Multi-Project Support Tests
+// Tests for --project flags, project persistence, and issue namespacing
+// ============================================================================
+
+// createTestProject creates a project fixture with .beads/beads.jsonl
+func createTestProject(t *testing.T, baseDir, name string, issues []string) string {
+	t.Helper()
+	projectDir := filepath.Join(baseDir, name)
+	beadsDir := filepath.Join(projectDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	var lines []string
+	for i, title := range issues {
+		lines = append(lines, strings.TrimSpace(`{"id":"`+strings.ToUpper(name)+`-`+itoa(i+1)+`","title":"`+title+`","status":"open","priority":1,"issue_type":"task"}`))
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "beads.jsonl"),
+		[]byte(strings.Join(lines, "\n")), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return projectDir
+}
+
+// createTestProjectWithIssueID creates a project with a specific issue ID
+func createTestProjectWithIssueID(t *testing.T, baseDir, name, issueID, title string) string {
+	t.Helper()
+	projectDir := filepath.Join(baseDir, name)
+	beadsDir := filepath.Join(projectDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	line := `{"id":"` + issueID + `","title":"` + title + `","status":"open","priority":1,"issue_type":"task"}`
+	if err := os.WriteFile(filepath.Join(beadsDir, "beads.jsonl"), []byte(line), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return projectDir
+}
+
+// Note: itoa is defined in export_pages_test.go and shared across the package
+
+// TestMultiProject_LoadTwoProjects verifies --project flag loads multiple projects
+func TestMultiProject_LoadTwoProjects(t *testing.T) {
+	bv := buildBvBinary(t)
+	baseDir := t.TempDir()
+
+	// Create two project dirs with issues
+	apiDir := createTestProject(t, baseDir, "api", []string{"API Endpoint", "API Auth"})
+	webDir := createTestProject(t, baseDir, "web", []string{"Dashboard", "Settings"})
+
+	// Run bv with both projects
+	cmd := exec.Command(bv, "--project", apiDir, "--project", webDir, "--robot-triage")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("bv failed: %v\n%s", err, out)
+	}
+
+	// Parse JSON output
+	var result map[string]interface{}
+	if err := json.Unmarshal(out, &result); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, out)
+	}
+
+	// Get triage data
+	triage, ok := result["triage"].(map[string]interface{})
+	if !ok {
+		t.Fatal("missing triage field")
+	}
+
+	quickRef, ok := triage["quick_ref"].(map[string]interface{})
+	if !ok {
+		t.Fatal("missing quick_ref")
+	}
+
+	// Verify total issue count (2 from api + 2 from web = 4)
+	openCount, ok := quickRef["open_count"].(float64)
+	if !ok || openCount != 4 {
+		t.Errorf("expected 4 open issues, got %v", quickRef["open_count"])
+	}
+
+	// Verify issues from both projects appear in recommendations
+	recommendations, ok := triage["recommendations"].([]interface{})
+	if !ok {
+		t.Log("Note: no recommendations returned")
+	} else {
+		// Check that we have issues from both projects
+		var foundAPI, foundWeb bool
+		for _, rec := range recommendations {
+			if recMap, ok := rec.(map[string]interface{}); ok {
+				id, _ := recMap["id"].(string)
+				if strings.HasPrefix(id, "api-") {
+					foundAPI = true
+				}
+				if strings.HasPrefix(id, "web-") {
+					foundWeb = true
+				}
+			}
+		}
+		if len(recommendations) >= 2 && (!foundAPI || !foundWeb) {
+			t.Log("Note: recommendations may not include all prefixed issues")
+		}
+	}
+}
+
+// TestMultiProject_IssueNamespacing verifies duplicate IDs get namespaced
+func TestMultiProject_IssueNamespacing(t *testing.T) {
+	bv := buildBvBinary(t)
+	baseDir := t.TempDir()
+
+	// Create two projects with SAME issue ID "TASK-1"
+	apiDir := createTestProjectWithIssueID(t, baseDir, "api", "TASK-1", "API Task")
+	webDir := createTestProjectWithIssueID(t, baseDir, "web", "TASK-1", "Web Task")
+
+	// Run bv with both projects
+	cmd := exec.Command(bv, "--project", apiDir, "--project", webDir, "--robot-triage")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("bv failed: %v\n%s", err, out)
+	}
+
+	// Parse JSON output
+	var result map[string]interface{}
+	if err := json.Unmarshal(out, &result); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, out)
+	}
+
+	// Verify we have 2 issues total (both TASK-1s should be loaded with different prefixes)
+	triage := result["triage"].(map[string]interface{})
+	quickRef := triage["quick_ref"].(map[string]interface{})
+
+	openCount := quickRef["open_count"].(float64)
+	if openCount != 2 {
+		t.Errorf("expected 2 open issues (both TASK-1s), got %v", openCount)
+	}
+
+	// The output string should contain both prefixed IDs
+	outStr := string(out)
+	if !strings.Contains(outStr, "api-TASK-1") {
+		t.Error("expected 'api-TASK-1' in output")
+	}
+	if !strings.Contains(outStr, "web-TASK-1") {
+		t.Error("expected 'web-TASK-1' in output")
+	}
+}
+
+// TestMultiProject_SaveProjects verifies --save-projects persists config
+func TestMultiProject_SaveProjects(t *testing.T) {
+	bv := buildBvBinary(t)
+	baseDir := t.TempDir()
+	configDir := t.TempDir()
+
+	// Create projects
+	apiDir := createTestProject(t, baseDir, "api", []string{"API Task"})
+	webDir := createTestProject(t, baseDir, "web", []string{"Web Task"})
+
+	// Run bv with --save-projects
+	cmd := exec.Command(bv, "--project", apiDir, "--project", webDir, "--save-projects", "--robot-triage")
+	cmd.Env = append(os.Environ(), "XDG_CONFIG_HOME="+configDir)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("bv failed: %v\n%s", err, out)
+	}
+
+	// Verify projects.yaml created
+	projectsPath := filepath.Join(configDir, "bv", "projects.yaml")
+	data, err := os.ReadFile(projectsPath)
+	if err != nil {
+		t.Fatalf("projects.yaml not created: %v", err)
+	}
+
+	// Parse YAML and verify contents
+	var config struct {
+		Projects []struct {
+			Name string `yaml:"name"`
+			Path string `yaml:"path"`
+		} `yaml:"projects"`
+	}
+	if err := yaml.Unmarshal(data, &config); err != nil {
+		t.Fatalf("invalid YAML: %v\n%s", err, data)
+	}
+
+	if len(config.Projects) != 2 {
+		t.Errorf("expected 2 projects in config, got %d", len(config.Projects))
+	}
+
+	// Verify both paths are saved
+	var foundAPI, foundWeb bool
+	for _, p := range config.Projects {
+		if p.Path == apiDir {
+			foundAPI = true
+		}
+		if p.Path == webDir {
+			foundWeb = true
+		}
+	}
+	if !foundAPI {
+		t.Error("api project not saved to config")
+	}
+	if !foundWeb {
+		t.Error("web project not saved to config")
+	}
+}
+
+// TestMultiProject_LoadSavedProjects verifies saved projects load automatically
+func TestMultiProject_LoadSavedProjects(t *testing.T) {
+	bv := buildBvBinary(t)
+	baseDir := t.TempDir()
+	configDir := t.TempDir()
+
+	// Create projects
+	apiDir := createTestProject(t, baseDir, "api", []string{"API Task"})
+	webDir := createTestProject(t, baseDir, "web", []string{"Web Task"})
+
+	// Manually create projects.yaml
+	bvConfigDir := filepath.Join(configDir, "bv")
+	if err := os.MkdirAll(bvConfigDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	configYAML := `projects:
+  - name: api
+    path: ` + apiDir + `
+  - name: web
+    path: ` + webDir + `
+`
+	if err := os.WriteFile(filepath.Join(bvConfigDir, "projects.yaml"), []byte(configYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Run bv WITHOUT --project flags (should load from saved config)
+	cmd := exec.Command(bv, "--robot-triage")
+	cmd.Env = append(os.Environ(), "XDG_CONFIG_HOME="+configDir)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("bv failed: %v\n%s", err, out)
+	}
+
+	// Verify issues from saved projects appear
+	var result map[string]interface{}
+	if err := json.Unmarshal(out, &result); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, out)
+	}
+
+	triage := result["triage"].(map[string]interface{})
+	quickRef := triage["quick_ref"].(map[string]interface{})
+
+	openCount := quickRef["open_count"].(float64)
+	if openCount != 2 {
+		t.Errorf("expected 2 open issues from saved projects, got %v", openCount)
+	}
+}
+
+// TestMultiProject_ClearProjects verifies --clear-projects removes config
+func TestMultiProject_ClearProjects(t *testing.T) {
+	bv := buildBvBinary(t)
+	configDir := t.TempDir()
+
+	// Create a projects.yaml file
+	bvConfigDir := filepath.Join(configDir, "bv")
+	if err := os.MkdirAll(bvConfigDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	projectsPath := filepath.Join(bvConfigDir, "projects.yaml")
+	if err := os.WriteFile(projectsPath, []byte("projects:\n  - path: /fake/path\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify file exists
+	if _, err := os.Stat(projectsPath); os.IsNotExist(err) {
+		t.Fatal("projects.yaml should exist before clear")
+	}
+
+	// Run bv --clear-projects
+	cmd := exec.Command(bv, "--clear-projects")
+	cmd.Env = append(os.Environ(), "XDG_CONFIG_HOME="+configDir)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("bv --clear-projects failed: %v\n%s", err, out)
+	}
+
+	// Verify file is removed
+	if _, err := os.Stat(projectsPath); !os.IsNotExist(err) {
+		t.Error("projects.yaml should be removed after --clear-projects")
+	}
+}
+
+// TestMultiProject_RepoFilter verifies --repo filters by prefix
+func TestMultiProject_RepoFilter(t *testing.T) {
+	bv := buildBvBinary(t)
+	baseDir := t.TempDir()
+
+	// Create two projects
+	apiDir := createTestProject(t, baseDir, "api", []string{"API Task 1", "API Task 2"})
+	webDir := createTestProject(t, baseDir, "web", []string{"Web Task 1", "Web Task 2"})
+
+	// Run bv with --repo filter for api only
+	cmd := exec.Command(bv, "--project", apiDir, "--project", webDir, "--repo", "api", "--robot-triage")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("bv failed: %v\n%s", err, out)
+	}
+
+	// Parse JSON output
+	var result map[string]interface{}
+	if err := json.Unmarshal(out, &result); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, out)
+	}
+
+	triage := result["triage"].(map[string]interface{})
+	quickRef := triage["quick_ref"].(map[string]interface{})
+
+	// Should only have 2 issues (from api), not 4
+	openCount := quickRef["open_count"].(float64)
+	if openCount != 2 {
+		t.Errorf("expected 2 open issues (api only), got %v", openCount)
+	}
+
+	// Verify only api issues in output
+	outStr := string(out)
+	if !strings.Contains(outStr, "api-") {
+		t.Error("expected api issues in filtered output")
+	}
+	if strings.Contains(outStr, "web-") {
+		t.Error("unexpected web issues in api-filtered output")
+	}
+}
+
+// TestMultiProject_DuplicateProjectNames verifies collision handling
+func TestMultiProject_DuplicateProjectNames(t *testing.T) {
+	bv := buildBvBinary(t)
+	baseDir := t.TempDir()
+
+	// Create two projects with SAME directory name in different parent dirs
+	parentA := filepath.Join(baseDir, "a")
+	parentB := filepath.Join(baseDir, "b")
+
+	projA := createTestProject(t, parentA, "myproject", []string{"Task A"})
+	projB := createTestProject(t, parentB, "myproject", []string{"Task B"})
+
+	// Run bv with both projects
+	cmd := exec.Command(bv, "--project", projA, "--project", projB, "--robot-triage")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("bv failed: %v\n%s", err, out)
+	}
+
+	// Parse JSON output
+	var result map[string]interface{}
+	if err := json.Unmarshal(out, &result); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, out)
+	}
+
+	triage := result["triage"].(map[string]interface{})
+	quickRef := triage["quick_ref"].(map[string]interface{})
+
+	// Should have 2 issues total
+	openCount := quickRef["open_count"].(float64)
+	if openCount != 2 {
+		t.Errorf("expected 2 open issues, got %v", openCount)
+	}
+
+	// The prefixes should be distinct (e.g., myproject- and myproject_1-)
+	outStr := string(out)
+	// Check that we have both issues with distinct prefixes
+	if !strings.Contains(outStr, "myproject-") {
+		t.Error("expected 'myproject-' prefix in output")
+	}
+	// The second project should get a disambiguated prefix
+	if !strings.Contains(outStr, "myproject_1-") && !strings.Contains(outStr, "myproject_2-") {
+		t.Log("Note: expected disambiguated prefix like 'myproject_1-' for duplicate dir name")
+	}
+}
+
+// TestMultiProject_CrossProjectDependencies verifies deps across projects
+func TestMultiProject_CrossProjectDependencies(t *testing.T) {
+	bv := buildBvBinary(t)
+	baseDir := t.TempDir()
+
+	// Create api project with API-1
+	apiDir := filepath.Join(baseDir, "api")
+	beadsDir := filepath.Join(apiDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	apiIssue := `{"id":"API-1","title":"API Endpoint","status":"open","priority":1,"issue_type":"task"}`
+	if err := os.WriteFile(filepath.Join(beadsDir, "beads.jsonl"), []byte(apiIssue), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create web project with WEB-1 that depends on api-API-1
+	webDir := filepath.Join(baseDir, "web")
+	beadsDir = filepath.Join(webDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Note: cross-project dependency uses the prefixed ID "api-API-1"
+	webIssue := `{"id":"WEB-1","title":"Web Dashboard","status":"open","priority":1,"issue_type":"task","dependencies":[{"depends_on_id":"api-API-1","type":"blocks"}]}`
+	if err := os.WriteFile(filepath.Join(beadsDir, "beads.jsonl"), []byte(webIssue), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Run bv with both projects
+	cmd := exec.Command(bv, "--project", apiDir, "--project", webDir, "--robot-plan")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("bv failed: %v\n%s", err, out)
+	}
+
+	// Parse JSON output
+	var result map[string]interface{}
+	if err := json.Unmarshal(out, &result); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, out)
+	}
+
+	// Verify plan structure
+	plan, ok := result["plan"].(map[string]interface{})
+	if !ok {
+		t.Fatal("missing plan field")
+	}
+
+	// Check for tracks
+	tracks, ok := plan["tracks"].([]interface{})
+	if !ok {
+		t.Fatal("missing tracks field")
+	}
+
+	// Should have tracks (exact structure depends on implementation)
+	if len(tracks) == 0 {
+		t.Error("expected at least one track in execution plan")
+	}
+
+	// The dependency graph should show both issues
+	outStr := string(out)
+	if !strings.Contains(outStr, "api-API-1") {
+		t.Error("expected 'api-API-1' in plan output")
+	}
+	if !strings.Contains(outStr, "web-WEB-1") {
+		t.Error("expected 'web-WEB-1' in plan output")
+	}
+}


### PR DESCRIPTION
Add ability to load and manage multiple beads projects in a single TUI session:
- `--project` flag (repeatable) to load multiple project directories
- `--save-projects` to persist project list to ~/.config/bv/projects.yaml
- `--clear-projects` to remove saved project configuration
- Issue namespacing with project prefixes (e.g., api-TASK-1, web-TASK-1)
- Project manager UI overlay (P key) for runtime add/remove/toggle
- MultiWatcher for monitoring changes across all project files
- E2E tests covering all multi-project workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)