### PR TITLE
fix: enable scrolling in full-terminal detail view on small terminals

### DIFF
--- a/pkg/ui/coverage_extra_test.go
+++ b/pkg/ui/coverage_extra_test.go
@@ -113,11 +113,15 @@ func TestHandleListKeysFiltersAndTimeTravelPrompt(t *testing.T) {
 		t.Fatalf("ctrl+u should move selection up")
 	}
 
-	// Enter should flip showDetails in mobile view
+	// Enter should flip showDetails in mobile view and focus the detail viewport
 	m.showDetails = false
+	m.focused = focusList
 	m = m.handleListKeys(tea.KeyMsg{Type: tea.KeyEnter})
 	if !m.showDetails {
 		t.Fatalf("enter should show details when not split view")
+	}
+	if m.focused != focusDetail {
+		t.Fatalf("enter should focus detail viewport for scrolling, got focus=%d", m.focused)
 	}
 
 	// Time-travel prompt toggling

--- a/pkg/ui/model.go
+++ b/pkg/ui/model.go
@@ -1807,6 +1807,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				// q closes current view or quits if at top level
 				if m.showDetails && !m.isSplitView {
 					m.showDetails = false
+					m.focused = focusList
 					return m, nil
 				}
 				if m.focused == focusInsights {
@@ -1837,6 +1838,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				// Escape closes modals and goes back
 				if m.showDetails && !m.isSplitView {
 					m.showDetails = false
+					m.focused = focusList
 					return m, nil
 				}
 				if m.focused == focusInsights {
@@ -2357,6 +2359,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	// Update viewport if list selection changed in split view
 	if m.isSplitView && m.focused == focusList {
 		m.updateViewportContent()
+		m.viewport.GotoTop() // Reset scroll when selecting a new issue
 	}
 
 	// Trigger async semantic computation if needed (debounced)
@@ -2557,13 +2560,14 @@ func (m Model) handleBoardKeys(msg tea.KeyMsg) Model {
 				}
 			}
 			m.isBoardView = false
-			m.focused = focusList
 			if m.isSplitView {
 				m.focused = focusDetail
 			} else {
 				m.showDetails = true
+				m.focused = focusDetail
 			}
 			m.updateViewportContent()
+			m.viewport.GotoTop()
 		}
 	}
 	return m
@@ -2598,13 +2602,14 @@ func (m Model) handleGraphKeys(msg tea.KeyMsg) Model {
 				}
 			}
 			m.isGraphView = false
-			m.focused = focusList
 			if m.isSplitView {
 				m.focused = focusDetail
 			} else {
 				m.showDetails = true
+				m.focused = focusDetail
 			}
 			m.updateViewportContent()
+			m.viewport.GotoTop()
 		}
 	}
 	return m
@@ -2628,13 +2633,14 @@ func (m Model) handleActionableKeys(msg tea.KeyMsg) Model {
 				}
 			}
 			m.isActionableView = false
-			m.focused = focusList
 			if m.isSplitView {
 				m.focused = focusDetail
 			} else {
 				m.showDetails = true
+				m.focused = focusDetail
 			}
 			m.updateViewportContent()
+			m.viewport.GotoTop()
 		}
 	}
 	return m
@@ -3151,13 +3157,14 @@ func (m Model) handleInsightsKeys(msg tea.KeyMsg) Model {
 					break
 				}
 			}
-			m.focused = focusList
 			if m.isSplitView {
 				m.focused = focusDetail
 			} else {
 				m.showDetails = true
+				m.focused = focusDetail
 			}
 			m.updateViewportContent()
+			m.viewport.GotoTop()
 		}
 	}
 	return m
@@ -3169,7 +3176,9 @@ func (m Model) handleListKeys(msg tea.KeyMsg) Model {
 	case "enter":
 		if !m.isSplitView {
 			m.showDetails = true
+			m.focused = focusDetail // Allow viewport to receive scroll keys
 			m.updateViewportContent()
+			m.viewport.GotoTop()
 		}
 	case "home":
 		m.list.Select(0)


### PR DESCRIPTION
**Enable scrolling in full-terminal detail view on small terminals**

https://github.com/user-attachments/assets/789ce09d-0b07-40c7-916d-46aa9817bb31

## Problem

On narrow terminals, bv displays a full-screen detail view when pressing Enter on an issue. However, **keyboard scrolling doesn't work** - arrow keys, j/k, Page Up/Down, and other navigation keys have no effect on the viewport content.

This makes it impossible to read long issue descriptions, comments, or dependency trees on small terminal windows (common on laptops, split-screen setups, or when SSH'ing from mobile).

## Root Cause

When entering the full-screen detail view, the code sets `showDetails = true` but **does not update the focus state**. Focus remains on `focusList`, so key events continue being routed to the (hidden) list component instead of the visible viewport.

## Solution

This PR ensures proper focus management when entering/exiting the detail view:

1. **Set focus to `focusDetail`** when entering full-screen detail view from:
   - List view (Enter key)
   - Board view (Enter key)  
   - Graph view (Enter key)
   - Actionable view (Enter key)
   - Insights view (Enter key)

2. **Reset viewport to top** when selecting a new issue (prevents seeing stale scroll position from previous issue)

3. **Restore focus to `focusList`** when exiting detail view (q/Esc)

## Testing

- Tested on terminal widths from 80-200 columns
- Verified scrolling works with: arrow keys, j/k, Ctrl+d/u, Page Up/Down
- Verified focus correctly returns to list when pressing Esc or q
- Added test coverage for focus behavior

## Changes

- `pkg/ui/model.go`: Focus management fixes in 6 key handlers
- `pkg/ui/coverage_extra_test.go`: Test for Enter key focus behavior