### PR TITLE
feat: add Nix flake for reproducible development environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ benchmarks/current.txt
 .bv/
 beads_report_beads_viewer_*.md
 
+# Nix build artifacts
+result
+
 # Rust/WASM build artifacts
 bv-graph-wasm/target/
 bv-graph-wasm/pkg/

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1767325753,
+        "narHash": "sha256-yA/CuWyqm+AQo2ivGy6PlYrjZBQm7jfbe461+4HF2fo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "64049ca74d63e971b627b5f3178d95642e61cedd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,68 @@
+{
+  description = "bv - Terminal UI for the Beads issue tracker";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+
+        version = "0.11.3";
+
+        # To update vendorHash after go.mod/go.sum changes:
+        # 1. Change vendorHash to: pkgs.lib.fakeHash
+        # 2. Run: nix build .#bv 2>&1 | grep "got:"
+        # 3. Copy the hash from "got:" and paste it below
+        vendorHash = "sha256-rtIqTK6ez27kvPMbNjYSJKFLRbfUv88jq8bCfMkYjfs=";
+      in
+      {
+        packages = {
+          bv = pkgs.buildGoModule {
+            pname = "bv";
+            inherit version;
+
+            src = ./.;
+
+            inherit vendorHash;
+
+            subPackages = [ "cmd/bv" ];
+
+            ldflags = [
+              "-s"
+              "-w"
+              "-X github.com/Dicklesworthstone/beads_viewer/pkg/version.Version=v${version}"
+            ];
+
+            meta = with pkgs.lib; {
+              description = "Terminal UI for the Beads issue tracker";
+              homepage = "https://github.com/Dicklesworthstone/beads_viewer";
+              license = licenses.mit;
+              maintainers = [ ];
+              mainProgram = "bv";
+            };
+          };
+
+          default = self.packages.${system}.bv;
+        };
+
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            go
+            gopls
+            gotools
+            go-tools
+            delve
+          ];
+
+          shellHook = ''
+            echo "bv development shell"
+            echo "Go version: $(go version)"
+          '';
+        };
+      }
+    );
+}


### PR DESCRIPTION
## Summary
Adds Nix flake support for reproducible development environments and declarative builds.

## Motivation
Many developers use Nix flakes for **reproducible, declarative development environments** across their projects. This addition enables:

- **Reproducible builds**: Same Go version, same dependencies, every time
- **Zero-config development**: `nix develop` gives you the complete dev environment instantly
- **Declarative integration**: Use bv in NixOS configurations or other flake-based projects
- **Multi-project consistency**: Pin bv to a specific version across all your projects
- **No global pollution**: Dev tools available only in project context

## Implementation
- Uses **NixOS 25.11 stable** (not unstable) for stability
- `buildGoModule` with correct vendorHash for Go dependency management  
- `devShell` provides: Go 1.25.5, gopls, gotools, go-tools, delve
- Clear instructions for updating vendorHash after dependency changes

## Verification
- ✅ `nix flake check` passes all validations
- ✅ `nix build .#bv` builds successfully  
- ✅ `./result/bin/bv --version` returns v0.11.3
- ✅ `nix develop` provides working Go 1.25.5 environment

## Usage Examples

**As a development dependency:**
```nix
# In your project's flake.nix
{
  inputs.bv.url = "github:Dicklesworthstone/beads_viewer";
  
  outputs = { self, bv, ... }: {
    devShells.default = pkgs.mkShell {
      packages = [ bv.packages.${system}.default ];
    };
  };
}
```

**Direct installation:**
```bash
nix profile install github:Dicklesworthstone/beads_viewer
```

**Temporary use:**
```bash
nix run github:Dicklesworthstone/beads_viewer
```

## Testing
```bash
# Build
nix build .#bv
./result/bin/bv --version

# Development shell  
nix develop
go version  # Should show go1.25.5
```

## Notes
This is an illustrative PR per your contribution policy. The feature will remain available on my fork (tagged as `v0.11.3-nix`) for Nix users until you decide how to integrate it upstream.