### PR TITLE
Fix PowerShell variable syntax error in install.ps1

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -118,13 +118,12 @@ function Main {
     Write-Info "Building $BIN_NAME from source..."
 
     $env:CGO_ENABLED = "0"
-    try {
-        & go install "$REPO/cmd/$BIN_NAME@latest" 2>&1 | ForEach-Object { Write-Host $_ }
-        if ($LASTEXITCODE -ne 0) {
-            throw "go install failed with exit code $LASTEXITCODE"
-        }
-    } catch {
-        Write-Error2 "Failed to build ${BIN_NAME}: $_"
+    $prevErrorActionPreference = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    & go install "$REPO/cmd/$BIN_NAME@latest" 2>&1 | ForEach-Object { Write-Host $_ }
+    $ErrorActionPreference = $prevErrorActionPreference
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error2 "Failed to build ${BIN_NAME}: go install exited with code $LASTEXITCODE"
         exit 1
     }
 


### PR DESCRIPTION
## Problem

  The `install.ps1` script fails to run due to two PowerShell errors:

  ### Error 1: Variable Syntax Error (Line 127)

  When running via `irm "https://raw.githubusercontent.com/Dicklesworthstone/beads_viewer/main/install.ps1" | iex`:

  iex : At line:127 char:39
      Write-Error2 "Failed to build $BIN_NAME: $_"
                                    ~~~~~~~~~~
  Variable reference is not valid. ':' was not followed by a valid variable name character. Consider using ${} to
  delimit the name.
  At line:1 char:91
  - ... sercontent.com/Dicklesworthstone/beads_viewer/main/install.ps1" | iex
                                                                    ~~~
    - CategoryInfo          : ParserError: (:) [Invoke-Expression], ParseException
    - FullyQualifiedErrorId : InvalidVariableReferenceWithDrive,Microsoft.PowerShell.Commands.InvokeExpressionCommand

  **Cause:** PowerShell interprets `$BIN_NAME:` as a drive reference (like `C:`) instead of a variable followed by a colon.

  ### Error 2: Stderr Handling Error (Line 121-123)

  After fixing Error 1, the script fails during the build step:

  ==> Installing bv for Windows...
  ==> Using Go 1.25.5
  ==> Install directory: C:\Users\tajdi\go\bin
  ==> Building bv from source...
  go.exe : go: downloading github.com/Dicklesworthstone/beads_viewer v0.12.1
  At C:\Users\tajdi\beads_viewer\install.ps1:121 char:5
  & go install "$REPO/cmd/$BIN_NAME@latest" 2>&1 | ForEach-Object { ...
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    - CategoryInfo          : NotSpecified: (go: downloading..._viewer v0.12.1:String) [], RemoteException
    - FullyQualifiedErrorId : NativeCommandError

  **Cause:** The script has `$ErrorActionPreference = 'Stop'` which treats any stderr output as a fatal error. The `go install` command writes normal download progress messages to stderr, causing the installation to fail even though the command is succeeding.

  ## Solution

  ### Fix 1: Variable Delimiter (Line 127)
  Changed `$BIN_NAME:` to `${BIN_NAME}:` to explicitly delimit the variable name:

  ```powershell
  # Before:
  Write-Error2 "Failed to build $BIN_NAME: $_"

  # After:
  Write-Error2 "Failed to build ${BIN_NAME}: $_"

  Fix 2: Stderr Handling (Lines 120-128)

  Temporarily set $ErrorActionPreference = 'Continue' around the go install command to allow normal stderr output while still catching actual failures via exit code checking:

  # Before:
  $env:CGO_ENABLED = "0"
  try {
      & go install "$REPO/cmd/$BIN_NAME@latest" 2>&1 | ForEach-Object { Write-Host $_ }
      if ($LASTEXITCODE -ne 0) {
          throw "go install failed with exit code $LASTEXITCODE"
      }
  } catch {
      Write-Error2 "Failed to build $BIN_NAME: $_"
      exit 1
  }

  # After:
  $env:CGO_ENABLED = "0"
  $prevErrorActionPreference = $ErrorActionPreference
  $ErrorActionPreference = 'Continue'
  & go install "$REPO/cmd/$BIN_NAME@latest" 2>&1 | ForEach-Object { Write-Host $_ }
  $ErrorActionPreference = $prevErrorActionPreference
  if ($LASTEXITCODE -ne 0) {
      Write-Error2 "Failed to build ${BIN_NAME}: go install exited with code $LASTEXITCODE"
      exit 1
  }

  Testing

  - ✅ Script syntax validates correctly
  - ✅ Installation completes successfully with both fixes applied
  - ✅ Download progress messages display without causing false errors
  - ✅ Exit code checking still catches actual failures