### PR TITLE
fix: update vendorHash for new go.mod dependencies

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,7 @@
         # 1. Set vendorHash to: pkgs.lib.fakeHash
         # 2. Run: nix build .#bv 2>&1 | grep "got:"
         # 3. Replace vendorHash with the hash from "got:"
-        vendorHash = "sha256-rtIqTK6ez27kvPMbNjYSJKFLRbfUv88jq8bCfMkYjfs=";
+        vendorHash = "sha256-V8Bl5lW9vd7o1ZcQ6rvs3WJ1ueYX7xKnHTyRAASHlng=";
       in
       {
         packages = {


### PR DESCRIPTION
## Summary

Updates the Nix flake `vendorHash` to account for new dependencies added to `go.mod`.

## Problem

Nix builds fail with:
```
go: inconsistent vendoring in ...:
    github.com/goccy/go-json@v0.10.5: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
    pgregory.net/rapid@v1.2.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
```

## Fix

Recalculated `vendorHash` using the fake hash method documented in `flake.nix`.

Fixes #56

---
*This PR was created with assistance from Claude Code.*