### PR TITLE
Add hierarchical ID sort

### DIFF
--- a/pkg/ui/model.go
+++ b/pkg/ui/model.go
@@ -24,6 +24,7 @@ import (
 	"github.com/Dicklesworthstone/beads_viewer/pkg/recipe"
 	"github.com/Dicklesworthstone/beads_viewer/pkg/search"
 	"github.com/Dicklesworthstone/beads_viewer/pkg/updater"
+	"github.com/Dicklesworthstone/beads_viewer/pkg/util/beadid"
 	"github.com/Dicklesworthstone/beads_viewer/pkg/watcher"
 
 	"github.com/atotto/clipboard"
@@ -78,6 +79,8 @@ const (
 	SortCreatedDesc                 // By creation date, newest first
 	SortPriority                    // By priority only (ascending)
 	SortUpdated                     // By last update, newest first
+	SortIDAsc                       // By bead/issue ID hierarchical ascending (parent -> child)
+	SortIDDesc                      // By bead/issue ID hierarchical descending
 	numSortModes                    // Keep this last - used for cycling
 )
 
@@ -92,6 +95,10 @@ func (s SortMode) String() string {
 		return "Priority"
 	case SortUpdated:
 		return "Updated"
+	case SortIDAsc:
+		return "ID ↑"
+	case SortIDDesc:
+		return "ID ↓"
 	default:
 		return "Default"
 	}
@@ -5974,6 +5981,12 @@ func (m *Model) sortFilteredItems(items []list.Item, issues []model.Issue) {
 		case SortUpdated:
 			// Most recently updated first
 			return iItem.Issue.UpdatedAt.After(jItem.Issue.UpdatedAt)
+		case SortIDAsc:
+			// Hierarchical ID ascending (parent -> child)
+			return beadid.Less(iItem.Issue.ID, jItem.Issue.ID)
+		case SortIDDesc:
+			// Hierarchical ID descending
+			return beadid.Less(jItem.Issue.ID, iItem.Issue.ID)
 		default:
 			// Default: Open first, then priority, then newest
 			iClosed := isClosedLikeStatus(iItem.Issue.Status)
@@ -5986,6 +5999,7 @@ func (m *Model) sortFilteredItems(items []list.Item, issues []model.Issue) {
 			}
 			return iItem.Issue.CreatedAt.After(jItem.Issue.CreatedAt)
 		}
+
 	})
 
 	// Reorder items and issues based on sorted indices

--- a/pkg/util/beadid/beadid.go
+++ b/pkg/util/beadid/beadid.go
@@ -1,0 +1,59 @@
+package beadid
+
+import (
+	"strconv"
+	"strings"
+)
+
+// CompareBeadID compares two bead/issue IDs using hierarchical segment rules.
+// It splits IDs on '.' and compares segments pairwise. If both segments are
+// numeric, they are compared numerically. Otherwise comparison is
+// case-insensitive lexical. Returns -1 if a<b, 1 if a>b, 0 if equal.
+func CompareBeadID(a, b string) int {
+	sa := strings.Split(a, ".")
+	sb := strings.Split(b, ".")
+	na := len(sa)
+	nb := len(sb)
+	limit := na
+	if nb < limit {
+		limit = nb
+	}
+	for i := 0; i < limit; i++ {
+		xa := sa[i]
+		xb := sb[i]
+		ia, errA := strconv.Atoi(xa)
+		ib, errB := strconv.Atoi(xb)
+		if errA == nil && errB == nil {
+			if ia < ib {
+				return -1
+			}
+			if ia > ib {
+				return 1
+			}
+			// equal numeric -> continue
+		} else {
+			xaL := strings.ToLower(xa)
+			xbL := strings.ToLower(xb)
+			if xaL < xbL {
+				return -1
+			}
+			if xaL > xbL {
+				return 1
+			}
+			// equal lexical -> continue
+		}
+	}
+	// All compared segments equal; shorter ID (parent) comes first
+	if na < nb {
+		return -1
+	}
+	if na > nb {
+		return 1
+	}
+	return 0
+}
+
+// Less returns true if a < b according to CompareBeadID
+func Less(a, b string) bool {
+	return CompareBeadID(a, b) < 0
+}

--- a/pkg/util/beadid/beadid_test.go
+++ b/pkg/util/beadid/beadid_test.go
@@ -1,0 +1,49 @@
+package beadid
+
+import "testing"
+
+func TestCompareBeadID_BasicHierarchy(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want int
+	}{
+		{"bd-a3f8", "bd-a3f8.1", -1},
+		{"bd-a3f8.1", "bd-a3f8.1.1", -1},
+		{"bd-a3f8.1.1", "bd-a3f8.1", 1},
+	}
+	for _, c := range cases {
+		if got := CompareBeadID(c.a, c.b); got != c.want {
+			t.Fatalf("CompareBeadID(%q, %q) = %d, want %d", c.a, c.b, got, c.want)
+		}
+	}
+}
+
+func TestCompareBeadID_NumericSegments(t *testing.T) {
+	// verify Compare directly
+	if CompareBeadID("1.2", "1.10") != -1 {
+		t.Fatalf("expected 1.2 < 1.10")
+	}
+	if CompareBeadID("1.10", "1.2") != 1 {
+		t.Fatalf("expected 1.10 > 1.2")
+	}
+	// equal
+	if CompareBeadID("bd-x", "bd-x") != 0 {
+		t.Fatalf("expected equal")
+	}
+}
+
+func TestCompareBeadID_MixedAlphaNumeric(t *testing.T) {
+	in := []struct {
+		a, b string
+		want int
+	}{
+		{"bd-a3f8", "bd-b234", -1},
+		{"bd-a3f8.2", "bd-a3f8.10", -1},
+		{"Bd-X.2", "bd-x.10", -1},
+	}
+	for _, c := range in {
+		if got := CompareBeadID(c.a, c.b); got != c.want {
+			t.Fatalf("CompareBeadID(%q,%q)=%d want %d", c.a, c.b, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
Add SortIDAsc/SortIDDesc modes and a reusable bead ID comparator that orders IDs by dot-separated segments, comparing numeric segments numerically so parents sort before children (e.g., bd-a3f8 < bd-a3f8.1 < bd-a3f8.1.1). Include unit tests for the comparator.

This is related to the feature request in https://github.com/Dicklesworthstone/beads_viewer/issues/43 and brings a kind of Hierarchical view to the default / label view.
