### PR TITLE
fix: use composite comment ID to avoid workspace export conflicts

### DIFF
--- a/pkg/export/sqlite_export.go
+++ b/pkg/export/sqlite_export.go
@@ -286,12 +286,14 @@ func (e *SQLiteExporter) insertComments(db *sql.DB) error {
 	defer stmt.Close()
 
 	for _, issue := range e.Issues {
-		for _, comment := range issue.Comments {
+		for idx, comment := range issue.Comments {
 			if comment == nil {
 				continue
 			}
+			// Use composite ID to avoid conflicts in workspace mode
+			compositeID := fmt.Sprintf("%s_%d", issue.ID, idx+1)
 			_, err := stmt.Exec(
-				comment.ID,
+				compositeID,
 				issue.ID,
 				comment.Author,
 				comment.Text,

--- a/pkg/export/sqlite_schema.go
+++ b/pkg/export/sqlite_schema.go
@@ -72,9 +72,10 @@ func createCoreTables(db *sql.DB) error {
 	}
 
 	// Comments table - issue discussion threads (bv-52)
+	// id is TEXT to support composite IDs (issue_id + index) in workspace mode
 	commentsSQL := `
 		CREATE TABLE IF NOT EXISTS comments (
-			id INTEGER PRIMARY KEY,
+			id TEXT PRIMARY KEY,
 			issue_id TEXT NOT NULL,
 			author TEXT,
 			text TEXT NOT NULL,


### PR DESCRIPTION
## Summary
When exporting with `-workspace` flag, comment IDs from different projects can conflict since they are sequential per issue (1, 2, 3...).

## Changes
- Use composite ID format: `{issue_id}_{index}` (e.g., `clawd-abc_1`)
- Change `comments.id` schema from `INTEGER` to `TEXT PRIMARY KEY`

## Testing
Tested with workspace config containing 8 repos and 135 issues — export succeeds.

Fixes #76