### PR TITLE
fix(preview): remove Content-Length header in livereload middleware

### DIFF
--- a/pkg/export/livereload.go
+++ b/pkg/export/livereload.go
@@ -258,6 +258,13 @@ type injectingResponseWriter struct {
 	committed bool
 }
 
+func (w *injectingResponseWriter) WriteHeader(code int) {
+	// Remove Content-Length because we will inject extra bytes,
+	// making the original length incorrect.
+	w.Header().Del("Content-Length")
+	w.ResponseWriter.WriteHeader(code)
+}
+
 func (w *injectingResponseWriter) Write(b []byte) (int, error) {
 	if w.committed {
 		return w.ResponseWriter.Write(b)


### PR DESCRIPTION
## Problem

The live-reload middleware (`2b46353`) injects an SSE `<script>` (~815 bytes) into HTML responses, but `http.FileServer` has already set `Content-Length` based on the original file size. Browsers see more bytes than expected and abort — resulting in a **blank page**.

```
Content-Length: 301987  ← original file
Actual body:   302802  ← after injection
→ curl: transfer closed with 301987 bytes remaining to read
```

## Fix

Override `WriteHeader` on `injectingResponseWriter` to delete `Content-Length` before headers are sent. Go automatically switches to chunked transfer encoding.

```go
func (w *injectingResponseWriter) WriteHeader(code int) {
    w.Header().Del("Content-Length")
    w.ResponseWriter.WriteHeader(code)
}
```

## Testing

Before fix: `curl -v http://127.0.0.1:9000/` → 0 bytes received, connection aborted
After fix: full HTML with injected SSE script, chunked transfer encoding

Fixes #84