### PR TITLE
fix(sqlite): read labels from separate labels table when issues.labels column is absent (br/beads-rs compat)

### DIFF
--- a/internal/datasource/sqlite.go
+++ b/internal/datasource/sqlite.go
@@ -62,20 +62,55 @@ func (r *SQLiteReader) LoadIssues() ([]model.Issue, error) {
 	return r.LoadIssuesFiltered(nil)
 }
 
+// hasLabelsColumn reports whether the issues table has a labels column.
+// Some beads clients (e.g. br/beads-rs) store labels in a separate labels
+// table instead of a JSON column on the issues row.
+func (r *SQLiteReader) hasLabelsColumn() bool {
+	rows, err := r.db.Query("PRAGMA table_info(issues)")
+	if err != nil {
+		return false
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var cid int
+		var name, typ string
+		var notNull, pk int
+		var dfltValue sql.NullString
+		if err := rows.Scan(&cid, &name, &typ, &notNull, &dfltValue, &pk); err != nil {
+			continue
+		}
+		if strings.EqualFold(name, "labels") {
+			return true
+		}
+	}
+	return false
+}
+
 // LoadIssuesFiltered reads issues matching the filter function
 func (r *SQLiteReader) LoadIssuesFiltered(filter func(*model.Issue) bool) ([]model.Issue, error) {
-	// Query for all non-tombstone issues
-	query := `
+	// Detect whether this is a native bv database (labels column on issues)
+	// or a br/beads-rs database (labels in a separate labels table).
+	// We check once per call; the result is stable for the lifetime of a query.
+	useLabelsColumn := r.hasLabelsColumn()
+
+	labelsExpr := "i.labels"
+	if !useLabelsColumn {
+		// Aggregate labels from the separate labels table as a JSON array.
+		// This handles br-format databases where labels live in their own table.
+		labelsExpr = `(SELECT json_group_array(label) FROM labels WHERE issue_id = i.id)`
+	}
+
+	query := fmt.Sprintf(`
 		SELECT
-			id, title, description, status, priority, issue_type,
-			assignee, estimated_minutes, created_at, updated_at,
-			due_date, closed_at, external_ref, compaction_level,
-			compacted_at, compacted_at_commit, original_size,
-			labels, design, acceptance_criteria, notes, source_repo
-		FROM issues
-		WHERE (tombstone IS NULL OR tombstone = 0)
-		ORDER BY updated_at DESC
-	`
+			i.id, i.title, i.description, i.status, i.priority, i.issue_type,
+			i.assignee, i.estimated_minutes, i.created_at, i.updated_at,
+			i.due_date, i.closed_at, i.external_ref, i.compaction_level,
+			i.compacted_at, i.compacted_at_commit, i.original_size,
+			%s, i.design, i.acceptance_criteria, i.notes, i.source_repo
+		FROM issues i
+		WHERE (i.tombstone IS NULL OR i.tombstone = 0)
+		ORDER BY i.updated_at DESC
+	`, labelsExpr)
 
 	rows, err := r.db.Query(query)
 	if err != nil {

--- a/internal/datasource/sqlite_labels_test.go
+++ b/internal/datasource/sqlite_labels_test.go
@@ -1,0 +1,191 @@
+package datasource
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	_ "modernc.org/sqlite"
+	"database/sql"
+)
+
+// TestSQLiteReaderLabelsFromSeparateTable verifies that labels stored in a
+// separate `labels` table (br/beads-rs format) are correctly loaded and
+// exported — i.e. watch-export does not silently drop labels on re-export.
+func TestSQLiteReaderLabelsFromSeparateTable(t *testing.T) {
+	// Create a temporary br-format SQLite database (no labels column on issues).
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "beads.db")
+
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	_, err = db.Exec(`
+		CREATE TABLE issues (
+			id TEXT PRIMARY KEY,
+			title TEXT NOT NULL,
+			description TEXT NOT NULL DEFAULT '',
+			status TEXT NOT NULL DEFAULT 'open',
+			priority INTEGER NOT NULL DEFAULT 2,
+			issue_type TEXT NOT NULL DEFAULT 'task',
+			assignee TEXT,
+			estimated_minutes INTEGER,
+			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			due_date DATETIME,
+			closed_at DATETIME,
+			external_ref TEXT,
+			compaction_level INTEGER DEFAULT 0,
+			compacted_at DATETIME,
+			compacted_at_commit TEXT,
+			original_size INTEGER,
+			design TEXT NOT NULL DEFAULT '',
+			acceptance_criteria TEXT NOT NULL DEFAULT '',
+			notes TEXT NOT NULL DEFAULT '',
+			source_repo TEXT,
+			tombstone INTEGER DEFAULT 0
+		);
+		CREATE TABLE labels (
+			issue_id TEXT NOT NULL,
+			label TEXT NOT NULL,
+			PRIMARY KEY (issue_id, label)
+		);
+		CREATE TABLE dependencies (
+			issue_id TEXT NOT NULL,
+			depends_on_id TEXT NOT NULL,
+			dependency_type TEXT NOT NULL DEFAULT 'blocks',
+			PRIMARY KEY (issue_id, depends_on_id)
+		);
+		CREATE TABLE comments (
+			id TEXT PRIMARY KEY,
+			issue_id TEXT NOT NULL,
+			author TEXT,
+			text TEXT,
+			created_at DATETIME
+		);
+	`)
+	if err != nil {
+		t.Fatalf("create schema: %v", err)
+	}
+
+	_, err = db.Exec(`INSERT INTO issues (id, title) VALUES ('test-1', 'Test Issue')`)
+	if err != nil {
+		t.Fatalf("insert issue: %v", err)
+	}
+	_, err = db.Exec(`INSERT INTO labels (issue_id, label) VALUES ('test-1', 'approved'), ('test-1', 'prue')`)
+	if err != nil {
+		t.Fatalf("insert labels: %v", err)
+	}
+	db.Close()
+
+	// Now read via SQLiteReader (same path as watch-export uses).
+	source := DataSource{
+		Type:  SourceTypeSQLite,
+		Path:  dbPath,
+		Valid: true,
+	}
+	reader, err := NewSQLiteReader(source)
+	if err != nil {
+		t.Fatalf("NewSQLiteReader: %v", err)
+	}
+	defer reader.Close()
+
+	issues, err := reader.LoadIssues()
+	if err != nil {
+		t.Fatalf("LoadIssues: %v", err)
+	}
+	if len(issues) != 1 {
+		t.Fatalf("expected 1 issue, got %d", len(issues))
+	}
+
+	issue := issues[0]
+	labelSet := make(map[string]bool)
+	for _, l := range issue.Labels {
+		labelSet[l] = true
+	}
+
+	if !labelSet["approved"] {
+		t.Errorf("expected label 'approved' in %v", issue.Labels)
+	}
+	if !labelSet["prue"] {
+		t.Errorf("expected label 'prue' in %v", issue.Labels)
+	}
+}
+
+// TestSQLiteReaderLabelsColumnPreserved verifies that native bv-format
+// databases (labels as JSON column on issues) still work correctly.
+func TestSQLiteReaderLabelsColumnPreserved(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "beads.db")
+
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+
+	_, err = db.Exec(`
+		CREATE TABLE issues (
+			id TEXT PRIMARY KEY,
+			title TEXT NOT NULL,
+			description TEXT NOT NULL DEFAULT '',
+			status TEXT NOT NULL DEFAULT 'open',
+			priority INTEGER NOT NULL DEFAULT 2,
+			issue_type TEXT NOT NULL DEFAULT 'task',
+			assignee TEXT,
+			estimated_minutes INTEGER,
+			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			due_date DATETIME,
+			closed_at DATETIME,
+			external_ref TEXT,
+			compaction_level INTEGER DEFAULT 0,
+			compacted_at DATETIME,
+			compacted_at_commit TEXT,
+			original_size INTEGER,
+			labels TEXT,
+			design TEXT NOT NULL DEFAULT '',
+			acceptance_criteria TEXT NOT NULL DEFAULT '',
+			notes TEXT NOT NULL DEFAULT '',
+			source_repo TEXT,
+			tombstone INTEGER DEFAULT 0
+		);
+		CREATE TABLE dependencies (issue_id TEXT, depends_on_id TEXT, dependency_type TEXT);
+		CREATE TABLE comments (id TEXT PRIMARY KEY, issue_id TEXT, author TEXT, text TEXT, created_at DATETIME);
+	`)
+	if err != nil {
+		t.Fatalf("create schema: %v", err)
+	}
+
+	_, err = db.Exec(`INSERT INTO issues (id, title, labels) VALUES ('test-2', 'Native Issue', '["approved","prue"]')`)
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	db.Close()
+
+	source := DataSource{Type: SourceTypeSQLite, Path: dbPath, Valid: true}
+	reader, err := NewSQLiteReader(source)
+	if err != nil {
+		t.Fatalf("NewSQLiteReader: %v", err)
+	}
+	defer reader.Close()
+
+	issues, err := reader.LoadIssues()
+	if err != nil {
+		t.Fatalf("LoadIssues: %v", err)
+	}
+	if len(issues) != 1 {
+		t.Fatalf("expected 1 issue, got %d", len(issues))
+	}
+
+	labelSet := make(map[string]bool)
+	for _, l := range issues[0].Labels {
+		labelSet[l] = true
+	}
+	if !labelSet["approved"] || !labelSet["prue"] {
+		t.Errorf("expected approved+prue labels, got %v", issues[0].Labels)
+	}
+	_ = os.Remove(dbPath)
+}


### PR DESCRIPTION
## Problem

When `bv --watch-export` is used with a `br`/beads-rs database, label changes (e.g. `br label add`) are silently dropped from the re-export — requiring a full bv restart to pick them up.

**Root cause:** `br`/beads-rs stores labels in a dedicated `labels` table rather than as a JSON column on `issues`. `SQLiteReader` queries `SELECT labels FROM issues`, which fails (no such column). It falls back to `loadIssuesSimple`, which loads no labels at all. The exported `beads.sqlite3` ends up with empty label arrays even though the source DB has the labels.

This means the watch mechanism \*does\* fire (it detects the `issues.jsonl` change), but the subsequent re-export reads from SQLite via `SelectBestSource` (freshest wins) and loses all label data.

## Fix

- Add `hasLabelsColumn()` — inspects `PRAGMA table_info(issues)` to detect the schema variant.
- In `LoadIssuesFiltered()`, if no `labels` column exists on `issues`, substitute a `json_group_array` subquery against the `labels` table.
- The native bv column path is entirely unchanged; the subquery is only used for br-format databases.

## Tests

Two new tests in `internal/datasource/sqlite_labels_test.go`:

- `TestSQLiteReaderLabelsFromSeparateTable` — creates a br-format schema (no `labels` column, separate `labels` table), inserts `approved` + `prue` labels, asserts both survive `LoadIssues()`.
- `TestSQLiteReaderLabelsColumnPreserved` — creates a native bv-format schema (`labels` JSON column on `issues`), asserts existing behaviour is unaffected.

Both pass. Pre-existing failures in `pkg/loader` (macOS `/private/var` path normalisation) and `tests/e2e` (`-robot-insights` flag parsing) are unrelated and reproduce on `main` without this change.