### PR TITLE
fix(pages): preserve issue deep-links on cold load

### DIFF
--- a/pkg/export/viewer_assets/viewer.js
+++ b/pkg/export/viewer_assets/viewer.js
@@ -1888,6 +1888,10 @@ function filtersFromURL() {
  * Update URL with current filter state (without page reload)
  */
 function syncFiltersToURL(view, filters, sort, searchQuery) {
+  // Preserve issue deep-links on cold load; don't overwrite #/issue/:id
+  // with #/issues before the router has a chance to consume the hash.
+  if (window.location.hash && window.location.hash.startsWith('#/issue/')) return;
+
   const paramString = filtersToURL(filters, sort, searchQuery);
   const baseHash = `#/${view}`;
   const newHash = paramString ? `${baseHash}?${paramString}` : baseHash;

--- a/tests/e2e/export_pages_test.go
+++ b/tests/e2e/export_pages_test.go
@@ -1481,6 +1481,32 @@ func TestExportPages_GraphLayoutNodesCovered(t *testing.T) {
 	}
 }
 
+// TestExportPages_ViewerPreservesIssueDeepLinks verifies exported viewer.js
+// doesn't clobber an incoming #/issue/:id hash during cold-start init.
+func TestExportPages_ViewerPreservesIssueDeepLinks(t *testing.T) {
+	bv := buildBvBinary(t)
+	stageViewerAssets(t, bv)
+
+	repoDir := createSimpleRepo(t, 3)
+	exportDir := filepath.Join(repoDir, "bv-pages")
+
+	cmd := exec.Command(bv, "--export-pages", exportDir)
+	cmd.Dir = repoDir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("--export-pages failed: %v\n%s", err, out)
+	}
+
+	viewerJSBytes, err := os.ReadFile(filepath.Join(exportDir, "viewer.js"))
+	if err != nil {
+		t.Fatalf("read viewer.js: %v", err)
+	}
+	viewerJS := string(viewerJSBytes)
+
+	if !strings.Contains(viewerJS, "window.location.hash.startsWith('#/issue/')") {
+		t.Fatal("viewer.js missing deep-link guard for #/issue/:id")
+	}
+}
+
 // TestExportPages_PrecomputedLayoutUsedByViewer verifies viewer.js loads precomputed layout
 func TestExportPages_PrecomputedLayoutUsedByViewer(t *testing.T) {
 	bv := buildBvBinary(t)


### PR DESCRIPTION
## Summary
Preserve `#/issue/:id` deep-links when the exported static viewer cold-loads.

## Problem
A deep link like:

- `/i/workspace-w8su` → `/#/issue/workspace-w8su`

should open the issue detail view.

Instead, on cold load the viewer can overwrite the incoming `#/issue/:id` hash with `#/issues` before the router consumes it, so the app lands on the list view instead of the specific issue.

## Root cause
`loadIssues()` calls `syncFiltersToURL('issues', ...)`, and `syncFiltersToURL()` does a `history.replaceState(..., '#/issues')` during startup.

If the page was opened with `#/issue/:id`, that hash gets clobbered before `handleHashChange()` can route it.

## Fix
Add a small guard in `syncFiltersToURL()`:

- if the current hash already starts with `#/issue/`, return early
- otherwise keep existing URL sync behaviour unchanged

## Tests
Added an export-pages regression test that verifies the exported `viewer.js` contains the deep-link guard.

Ran locally:

```bash
go test ./tests/e2e -run 'TestExportPages_(ViewerPreservesIssueDeepLinks|PrecomputedLayoutUsedByViewer)$' -count=1
```
