### PR TITLE
[codex] fix robot-next actionable top pick

### DIFF
--- a/pkg/analysis/triage.go
+++ b/pkg/analysis/triage.go
@@ -471,9 +471,15 @@ func ComputeTriageFromAnalyzer(analyzer *Analyzer, stats *GraphStats, issues []m
 	// Compute enhanced triage scores (bv-147)
 	triageScores := computeTriageScoresFromImpact(impactScores, unblocksMap, analyzer, DefaultTriageScoringOptions())
 
-	// Build recommendations using enhanced scores (bv-148)
-	// Pass triageCtx instead of analyzer for cached blocker lookups (bv-k4az)
-	recommendations := buildRecommendationsFromTriageScores(triageScores, triageCtx, opts.TopN)
+	// Build recommendations using enhanced scores (bv-148).
+	// Top picks must be selected from the full scored set before truncating
+	// recommendations; otherwise --robot-next can report no actionable work
+	// when the top opts.TopN scored items are all blocked.
+	allRecommendations := buildRecommendationsFromTriageScores(triageScores, triageCtx, len(triageScores))
+	recommendations := allRecommendations
+	if len(recommendations) > opts.TopN {
+		recommendations = recommendations[:opts.TopN]
+	}
 
 	// Build quick wins
 	quickWins := buildQuickWins(impactScores, unblocksMap, opts.QuickWinN)
@@ -482,7 +488,7 @@ func ComputeTriageFromAnalyzer(analyzer *Analyzer, stats *GraphStats, issues []m
 	blockersToClear := buildBlockersToClearWithContext(triageCtx, unblocksMap, opts.BlockerN)
 
 	// Build top picks for quick ref
-	topPicks := buildTopPicks(recommendations, 3)
+	topPicks := buildTopPicks(allRecommendations, 3)
 
 	// Determine top issue for commands
 	topID := ""

--- a/pkg/analysis/triage_test.go
+++ b/pkg/analysis/triage_test.go
@@ -1555,6 +1555,67 @@ func TestBuildTopPicks_FiltersBlockedItems(t *testing.T) {
 	}
 }
 
+func TestComputeTriage_TopPicksSearchBeyondRecommendationLimit(t *testing.T) {
+	now := time.Date(2026, 4, 26, 12, 0, 0, 0, time.UTC)
+	issues := []model.Issue{
+		{
+			ID:        "ready-low-impact",
+			Title:     "Ready low impact",
+			Status:    model.StatusOpen,
+			Priority:  4,
+			IssueType: model.TypeTask,
+			UpdatedAt: now,
+		},
+	}
+	for i := 0; i < 8; i++ {
+		blockedID := "blocked-high-impact-" + string(rune('a'+i))
+		blockerID := "zz-gate-" + string(rune('a'+i))
+		issues = append(issues,
+			model.Issue{
+				ID:        blockedID,
+				Title:     "Blocked high impact",
+				Status:    model.StatusOpen,
+				Priority:  0,
+				IssueType: model.TypeBug,
+				Labels:    []string{"urgent"},
+				UpdatedAt: now.Add(-30 * 24 * time.Hour),
+				Dependencies: []*model.Dependency{
+					{
+						IssueID:     blockedID,
+						DependsOnID: blockerID,
+						Type:        model.DepBlocks,
+					},
+				},
+			},
+			model.Issue{
+				ID:        blockerID,
+				Title:     "Gate",
+				Status:    model.StatusOpen,
+				Priority:  4,
+				IssueType: model.TypeTask,
+				UpdatedAt: now,
+			},
+		)
+	}
+
+	analyzer := NewAnalyzer(issues)
+	stats := analyzer.AnalyzeAsync(context.Background())
+	stats.WaitForPhase2()
+
+	triage := ComputeTriageFromAnalyzer(analyzer, stats, issues, TriageOptions{TopN: 3}, now)
+	if len(triage.Recommendations) != 3 {
+		t.Fatalf("expected capped recommendations, got %d", len(triage.Recommendations))
+	}
+	if len(triage.QuickRef.TopPicks) == 0 {
+		t.Fatal("expected top picks to find actionable work beyond capped blocked recommendations")
+	}
+	for _, pick := range triage.QuickRef.TopPicks {
+		if blockers := analyzer.GetOpenBlockers(pick.ID); len(blockers) > 0 {
+			t.Fatalf("top pick %q is blocked by %v", pick.ID, blockers)
+		}
+	}
+}
+
 // TestBuildTopPicks_LimitRespected verifies the limit is respected when filtering.
 func TestBuildTopPicks_LimitRespected(t *testing.T) {
 	recommendations := []Recommendation{


### PR DESCRIPTION
## What changed

- Select `quick_ref.top_picks` from the full scored recommendation set before truncating the public `recommendations` list.
- Keep the `recommendations` output capped by `TopN` as before.
- Add a regression test where blocked high-score recommendations occupy the capped list but actionable work exists lower in the scored set.

## Why

`--robot-next` reads `quick_ref.top_picks`. Before this change, triage first truncated recommendations to `TopN`, then filtered blocked items out of that shortened list. If the highest-scoring `TopN` items were blocked, `--robot-next` could incorrectly return "No actionable items available" even when `GetActionableIssues()` had ready work.

## Validation

- `go test ./pkg/analysis -run 'TestComputeTriage_TopPicksSearchBeyondRecommendationLimit|TestBuildTopPicks_FiltersBlockedItems' -count=1`
- `go build ./...`
- `go vet ./...`
- `go test ./...`
- Source-built `bv --robot-next` against `../crewday/.beads/issues.jsonl` returned an actionable issue.

Note: `gofmt -l .` still reports unrelated pre-existing formatting drift, including vendor files; the touched files are clean. `ubs` was unavailable in the local environment.
