### PR TITLE
feat(ui): light/dark theme selection for readable colors on light terminals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,18 @@ All notable changes to **Beads Viewer (`bv`)** are documented here. Versions are
 
 ### Added
 
+- **Light/dark theme selection for readable colors on light terminals (bv-128).** `bv` already
+  ships adaptive light and dark palettes, but the theme could only be nudged via `BV_THEME`, and
+  that override was applied only to a per-model renderer — most of the UI (badges, dividers,
+  markdown, and the bulk of styles built with the package-global `lipgloss.NewStyle()`) resolved
+  against the *default* renderer, which nobody overrode. When background auto-detection failed
+  (common over SSH/`tmux`, where lipgloss falls back to a **dark** background) light-terminal users
+  got unreadable near-white text with no working escape hatch. There is now a `--theme` flag
+  (`light` | `dark` | `auto`) and a top-level `theme:` key in `~/.config/bv/config.yaml`, resolved
+  with the precedence `--theme` → `BV_THEME` → config → auto-detect, and applied to the **global**
+  lipgloss renderer so every adaptive color agrees. Invalid `--theme` values warn and fall back to
+  auto-detect.
+
 - **Bounded robot liveness for the triage history prologue (#166).** The git-history correlation
   step of `--robot-triage` / `--robot-next` now runs under a hard budget (default 10 s),
   overridable via `--robot-history-timeout-ms` or `BV_ROBOT_HISTORY_TIMEOUT_MS` (`0` =

--- a/README.md
+++ b/README.md
@@ -3774,6 +3774,38 @@ The UI uses a visually distinct, high-contrast theme inspired by Dracula Princip
 *   **Status Open:** `#50FA7B` (Green)
 *   **Status Blocked:** `#FF5555` (Red)
 
+#### Light & dark terminals
+
+`bv` ships **both a light and a dark palette** and picks one to match your terminal
+background. Every color is WCAG-AA tuned for its background, so text stays readable
+either way.
+
+By default `bv` **auto-detects** the terminal background. Detection is unreliable in
+some environments (SSH, `tmux`/`screen`, terminals that don't answer the background
+query), where it falls back to assuming a **dark** background — which makes the light
+(near-white) text unreadable on a light terminal. If that happens, pin the theme
+explicitly:
+
+```bash
+bv --theme light      # force the light palette (dark text on light background)
+bv --theme dark       # force the dark palette (light text on dark background)
+bv --theme auto       # force auto-detection (the default)
+```
+
+You can also set it persistently, without passing the flag every time:
+
+```bash
+# Environment variable (e.g. in your shell profile)
+export BV_THEME=light
+```
+
+```yaml
+# ~/.config/bv/config.yaml
+theme: light   # light | dark | auto
+```
+
+**Precedence:** `--theme` flag → `BV_THEME` env var → `~/.config/bv/config.yaml` → auto-detect.
+
 ---
 
 ## 📄 License

--- a/cmd/bv/main.go
+++ b/cmd/bv/main.go
@@ -77,6 +77,7 @@ var rootHelpSections = []flagHelpSection{
 				"profile-json",
 				"no-cache",
 				"force-full-analysis",
+				"theme",
 				"background-mode",
 				"no-background-mode",
 			)
@@ -1577,6 +1578,8 @@ func main() {
 	debugRender := flag.String("debug-render", "", "Render a view and output to file (views: insights, board)")
 	debugWidth := flag.Int("debug-width", 180, "Width for debug render")
 	debugHeight := flag.Int("debug-height", 50, "Height for debug render")
+	// Color theme selection (bv-128): light, dark, or auto (default).
+	themeFlag := flag.String("theme", "", "Color theme for the TUI: light, dark, or auto (default: auto-detect terminal background)")
 	// Experimental background snapshot worker (bv-o11l)
 	backgroundMode := flag.Bool("background-mode", false, "Enable experimental background snapshot loading (TUI only)")
 	noBackgroundMode := flag.Bool("no-background-mode", false, "Disable experimental background snapshot loading (TUI only)")
@@ -1683,6 +1686,17 @@ func main() {
 		NotReadyLabels:          robotNotReadyLabels,
 	})
 	rootCmd := newRootCommand(func() error {
+		// Resolve and apply the color theme before any styling is computed, so
+		// every adaptive color (global styles, badges, markdown) agrees on the
+		// terminal background. Precedence: --theme > BV_THEME > config > auto.
+		// This is what makes light terminals readable when auto-detection fails
+		// (e.g. over SSH/tmux, where lipgloss falls back to a dark background). (bv-128)
+		if flag.CommandLine.Changed("theme") && normalizeThemePreference(*themeFlag) == "" &&
+			strings.TrimSpace(*themeFlag) != "" {
+			fmt.Fprintf(os.Stderr, "Warning: invalid --theme value %q (expected light, dark, or auto); using auto-detect\n", *themeFlag)
+		}
+		ui.SetThemeOverride(resolveThemePreference(*themeFlag, flag.CommandLine.Changed("theme")))
+
 		modifierRules := []modifierFlagRule{
 			{modifier: "robot-diff", requires: []string{"diff-since"}},
 			{modifier: "robot-search", requires: []string{"search"}},
@@ -5585,6 +5599,74 @@ func countEdges(issues []model.Issue) int {
 		}
 	}
 	return count
+}
+
+// normalizeThemePreference canonicalizes a theme string to "light", "dark",
+// "auto", or "" (unrecognized/empty). Matching is case-insensitive and
+// whitespace-tolerant.
+func normalizeThemePreference(s string) string {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "light":
+		return "light"
+	case "dark":
+		return "dark"
+	case "auto":
+		return "auto"
+	default:
+		return ""
+	}
+}
+
+// resolveThemePreference determines the effective color-theme preference using
+// the precedence: --theme flag > BV_THEME env var > ~/.config/bv/config.yaml >
+// auto-detect. It returns "light", "dark", "auto", or "" when nothing is
+// specified (in which case auto-detection is used). An invalid --theme value is
+// treated as "auto" so the flag never silently falls through to a lower-priority
+// source the user did not intend. (bv-128)
+func resolveThemePreference(flagVal string, flagChanged bool) string {
+	if flagChanged {
+		if v := normalizeThemePreference(flagVal); v != "" {
+			return v
+		}
+		return "auto" // explicit but invalid → honor the flag level as auto
+	}
+	if v := normalizeThemePreference(os.Getenv("BV_THEME")); v != "" {
+		return v
+	}
+	if v, ok := loadThemeFromUserConfig(); ok {
+		if nv := normalizeThemePreference(v); nv != "" {
+			return nv
+		}
+	}
+	return ""
+}
+
+// loadThemeFromUserConfig reads the top-level `theme:` key from
+// ~/.config/bv/config.yaml. It returns (value, true) when the key is present and
+// non-empty, else ("", false). Validation of the value happens in
+// normalizeThemePreference. (bv-128)
+func loadThemeFromUserConfig() (string, bool) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil || homeDir == "" {
+		return "", false
+	}
+	configPath := filepath.Join(homeDir, ".config", "bv", "config.yaml")
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return "", false
+	}
+
+	var cfg struct {
+		Theme string `yaml:"theme"`
+	}
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return "", false
+	}
+	if strings.TrimSpace(cfg.Theme) == "" {
+		return "", false
+	}
+	return cfg.Theme, true
 }
 
 func loadBackgroundModeFromUserConfig() (bool, bool) {

--- a/cmd/bv/theme_pref_test.go
+++ b/cmd/bv/theme_pref_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNormalizeThemePreference(t *testing.T) {
+	cases := map[string]string{
+		"light":    "light",
+		"LIGHT":    "light",
+		"  dark ":  "dark",
+		"Dark":     "dark",
+		"Auto":     "auto",
+		"":         "",
+		"blue":     "",
+		"lightish": "",
+	}
+	for in, want := range cases {
+		if got := normalizeThemePreference(in); got != want {
+			t.Errorf("normalizeThemePreference(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// writeThemeConfig writes a ~/.config/bv/config.yaml with the given body under a
+// fresh temp HOME and returns that HOME directory.
+func writeThemeConfig(t *testing.T, body string) string {
+	t.Helper()
+	home := t.TempDir()
+	dir := filepath.Join(home, ".config", "bv")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write config.yaml: %v", err)
+	}
+	return home
+}
+
+func TestLoadThemeFromUserConfig(t *testing.T) {
+	// Present and non-empty.
+	t.Setenv("HOME", writeThemeConfig(t, "theme: light\n"))
+	if v, ok := loadThemeFromUserConfig(); !ok || v != "light" {
+		t.Fatalf("loadThemeFromUserConfig() = (%q, %v), want (light, true)", v, ok)
+	}
+
+	// Key absent (other config present).
+	t.Setenv("HOME", writeThemeConfig(t, "experimental:\n  background_mode: true\n"))
+	if v, ok := loadThemeFromUserConfig(); ok {
+		t.Errorf("key absent: loadThemeFromUserConfig() = (%q, %v), want (_, false)", v, ok)
+	}
+
+	// No config file at all.
+	t.Setenv("HOME", t.TempDir())
+	if v, ok := loadThemeFromUserConfig(); ok {
+		t.Errorf("file absent: loadThemeFromUserConfig() = (%q, %v), want (_, false)", v, ok)
+	}
+}
+
+func TestResolveThemePreference(t *testing.T) {
+	// Flag (explicitly set) wins over env and config.
+	t.Setenv("HOME", writeThemeConfig(t, "theme: dark\n"))
+	t.Setenv("BV_THEME", "dark")
+	if got := resolveThemePreference("light", true); got != "light" {
+		t.Errorf("flag should win over env/config: got %q, want light", got)
+	}
+
+	// Explicitly-set but invalid flag → auto (does not fall through to env/config).
+	if got := resolveThemePreference("banana", true); got != "auto" {
+		t.Errorf("invalid explicit flag: got %q, want auto", got)
+	}
+
+	// Flag unset → env wins over config.
+	t.Setenv("HOME", writeThemeConfig(t, "theme: light\n"))
+	t.Setenv("BV_THEME", "dark")
+	if got := resolveThemePreference("", false); got != "dark" {
+		t.Errorf("env should win over config: got %q, want dark", got)
+	}
+
+	// Flag unset, env unset → config is used.
+	t.Setenv("HOME", writeThemeConfig(t, "theme: light\n"))
+	t.Setenv("BV_THEME", "")
+	if got := resolveThemePreference("", false); got != "light" {
+		t.Errorf("config should be used: got %q, want light", got)
+	}
+
+	// Nothing specified anywhere → empty (auto-detect).
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("BV_THEME", "")
+	if got := resolveThemePreference("", false); got != "" {
+		t.Errorf("no source: got %q, want empty", got)
+	}
+}

--- a/pkg/ui/theme.go
+++ b/pkg/ui/theme.go
@@ -12,8 +12,10 @@ import (
 // package init so every style helper can branch without re-detecting.
 var TermProfile colorprofile.Profile
 
-// BVThemeOverride holds the user's explicit theme preference from BV_THEME.
-// Values: "" (auto-detect), "dark", "light".
+// BVThemeOverride holds the user's explicit theme preference.
+// Values: "" (auto-detect), "dark", "light". It can be set from (in order of
+// precedence) the --theme flag, the BV_THEME env var, or ~/.config/bv/config.yaml.
+// Use SetThemeOverride to change it so the global renderer stays in sync.
 var BVThemeOverride string
 
 func init() {
@@ -23,8 +25,41 @@ func init() {
 	// This is useful when the terminal reports the wrong background color or
 	// when using themes that confuse auto-detection (e.g., Windows Terminal
 	// custom schemes, tmux, SSH). (bv-128)
+	//
+	// This only records the preference; the caller (cmd/bv) resolves the full
+	// flag > env > config precedence and calls SetThemeOverride once at startup,
+	// which is what actually applies it to the global renderer.
 	if v := strings.ToLower(strings.TrimSpace(os.Getenv("BV_THEME"))); v == "light" || v == "dark" {
 		BVThemeOverride = v
+	}
+}
+
+// SetThemeOverride records an explicit light/dark preference and applies it to
+// the GLOBAL lipgloss renderer via lipgloss.SetHasDarkBackground.
+//
+// This is the crucial step for light-terminal support: most of the UI is built
+// with the package-global lipgloss.NewStyle() (and markdown uses the global
+// lipgloss.HasDarkBackground()), so every AdaptiveColor resolves against the
+// default renderer. Setting only a per-model renderer — as older code did — left
+// the bulk of the UI stuck on auto-detection, which falls back to DARK when the
+// terminal does not answer the background query (common over SSH/tmux). By
+// pinning the global renderer here, light and dark themes render consistently.
+//
+// Accepted values are "light" and "dark"; "auto", "" or any unrecognized value
+// clears the override and leaves lipgloss's auto-detection in place. This should
+// be called once, early at startup, before styles are rendered. (bv-128)
+func SetThemeOverride(v string) {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "light":
+		BVThemeOverride = "light"
+		lipgloss.SetHasDarkBackground(false)
+	case "dark":
+		BVThemeOverride = "dark"
+		lipgloss.SetHasDarkBackground(true)
+	default:
+		// "auto", "", or unrecognized: leave the global renderer's
+		// auto-detection untouched so adaptive colors follow the terminal.
+		BVThemeOverride = ""
 	}
 }
 

--- a/pkg/ui/theme_test.go
+++ b/pkg/ui/theme_test.go
@@ -27,6 +27,52 @@ func isColorEmpty(c lipgloss.AdaptiveColor) bool {
 	return c.Light == "" && c.Dark == ""
 }
 
+func TestSetThemeOverride(t *testing.T) {
+	// SetThemeOverride mutates package-global and default-renderer state; save
+	// and restore so we don't leak into other tests.
+	savedOverride := BVThemeOverride
+	savedDark := lipgloss.HasDarkBackground()
+	defer func() {
+		BVThemeOverride = savedOverride
+		lipgloss.SetHasDarkBackground(savedDark)
+	}()
+
+	SetThemeOverride("light")
+	if BVThemeOverride != "light" {
+		t.Errorf("after light: BVThemeOverride = %q, want %q", BVThemeOverride, "light")
+	}
+	if lipgloss.HasDarkBackground() {
+		t.Error("after light: global HasDarkBackground() = true, want false")
+	}
+
+	SetThemeOverride("dark")
+	if BVThemeOverride != "dark" {
+		t.Errorf("after dark: BVThemeOverride = %q, want %q", BVThemeOverride, "dark")
+	}
+	if !lipgloss.HasDarkBackground() {
+		t.Error("after dark: global HasDarkBackground() = false, want true")
+	}
+
+	// Case-insensitive and whitespace-tolerant.
+	SetThemeOverride("  LIGHT ")
+	if BVThemeOverride != "light" || lipgloss.HasDarkBackground() {
+		t.Errorf("after '  LIGHT ': BVThemeOverride = %q, dark = %v; want light/false",
+			BVThemeOverride, lipgloss.HasDarkBackground())
+	}
+
+	// "auto" and unrecognized values clear the override.
+	SetThemeOverride("dark")
+	SetThemeOverride("auto")
+	if BVThemeOverride != "" {
+		t.Errorf("after auto: BVThemeOverride = %q, want empty", BVThemeOverride)
+	}
+	SetThemeOverride("dark")
+	SetThemeOverride("banana")
+	if BVThemeOverride != "" {
+		t.Errorf("after unrecognized value: BVThemeOverride = %q, want empty", BVThemeOverride)
+	}
+}
+
 func TestGetStatusColor(t *testing.T) {
 	renderer := lipgloss.NewRenderer(nil)
 	theme := DefaultTheme(renderer)


### PR DESCRIPTION
## Problem

Opening `bv` on a **light terminal** renders near-white text on a light background — effectively unreadable. There was no reliable way for a user to switch to a light-friendly palette.

## Root cause

`bv` already ships adaptive light **and** dark palettes (`lipgloss.AdaptiveColor{Light, Dark}`, WCAG-AA tuned). Which one is used depends on `lipgloss.HasDarkBackground()`, auto-detected via lipgloss/termenv. That detection **falls back to _dark_** whenever the terminal doesn't answer the background query — common over SSH, `tmux`/`screen`, and some emulators — so light-terminal users get the dark (light-text) palette.

The pre-existing `BV_THEME` env override didn't really help: it only called `SetHasDarkBackground()` on a **per-model** renderer, while the bulk of the UI — badges/dividers in `styles.go`, markdown via the global `lipgloss.HasDarkBackground()`, and the ~dozens of styles built with the package-global `lipgloss.NewStyle()` (57 in `model.go` alone) — resolves against the **default** renderer, which nothing overrode. So the override was mostly a no-op.

## Fix

- **`ui.SetThemeOverride`** now applies the preference to the **global** lipgloss renderer (`lipgloss.SetHasDarkBackground`), so every adaptive color — global styles, badges, markdown, and per-model renderers — agrees.
- New **`--theme` flag** (`light` | `dark` | `auto`) and a top-level **`theme:` key** in `~/.config/bv/config.yaml`.
- Preference resolved **once at startup** with precedence **`--theme` → `BV_THEME` → config → auto-detect**. Invalid `--theme` values warn on stderr and fall back to auto-detect.
- Auto-detect remains the default; this just adds a reliable, discoverable override.

```bash
bv --theme light            # force light palette (dark text)
bv --theme dark             # force dark palette
export BV_THEME=light       # persist via env
# ~/.config/bv/config.yaml → `theme: light`
```

## Verification

Rendered the insights view under each theme with color forced. Plain text is **identical** — only the ANSI colors differ, and they map exactly to the palette:

| | light theme | dark theme |
|---|---|---|
| body text | `#000000` black (readable on white) | `#F8F8F2` near-white (the bug) |
| status open | `#007700` dark green | `#50FA7B` bright green |
| type feature | `#B06800` dark orange | `#FFB86C` light orange |

Precedence confirmed against the built binary: `BV_THEME=dark --theme light` → light; `BV_THEME=light --theme dark` → dark; env-only and config-only both resolve correctly.

## Tests

- `pkg/ui`: `TestSetThemeOverride` (global renderer flips; case/whitespace tolerant; `auto`/unrecognized clears).
- `cmd/bv`: `TestNormalizeThemePreference`, `TestResolveThemePreference` (full precedence), `TestLoadThemeFromUserConfig`.
- Full `./pkg/ui/...` and `./cmd/bv/...` suites pass; `go vet` clean; `gofmt` clean.

Docs updated in `README.md` (Visual Theme → Light & dark terminals) and `CHANGELOG.md`.