### PR TITLE
fix(robot): honor future defer_until in ready picks

### DIFF
--- a/cmd/bv/main_robot_test.go
+++ b/cmd/bv/main_robot_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Dicklesworthstone/beads_viewer/pkg/analysis"
 	"github.com/Dicklesworthstone/beads_viewer/pkg/model"
@@ -224,6 +225,73 @@ func TestRobotNextEmitsClaimOnlyForSafeTopPick(t *testing.T) {
 	}
 }
 
+func TestRobotCommandsExcludeFutureDeferredClosedAndTombstoneIssues(t *testing.T) {
+	dir := t.TempDir()
+	beadsDir := filepath.Join(dir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		t.Fatalf("mkdir beads: %v", err)
+	}
+
+	beads := `{"id":"FUTURE-1","title":"Deferred by scheduler","status":"open","priority":0,"issue_type":"task","defer_until":"2026-09-20T07:00:00Z"}
+{"id":"READY-1","title":"Ready work","status":"open","priority":4,"issue_type":"task"}
+{"id":"CLOSED-1","title":"Closed work","status":"closed","priority":0,"issue_type":"task"}
+{"id":"TOMBSTONE-1","title":"Deleted work","status":"tombstone","priority":0,"issue_type":"task"}
+`
+	if err := os.WriteFile(filepath.Join(beadsDir, "beads.jsonl"), []byte(beads), 0o644); err != nil {
+		t.Fatalf("write beads: %v", err)
+	}
+
+	exe := buildTestBinary(t)
+	run := func(flag string, dst any) []byte {
+		t.Helper()
+		cmd := exec.Command(exe, flag, "--format=json")
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(), "SOURCE_DATE_EPOCH=1787320800")
+		out, err := cmd.Output()
+		if err != nil {
+			t.Fatalf("%s failed: %v", flag, err)
+		}
+		if err := json.Unmarshal(out, dst); err != nil {
+			t.Fatalf("%s json: %v\n%s", flag, err, out)
+		}
+		return out
+	}
+
+	var next struct {
+		Actionable bool   `json:"actionable"`
+		ID         string `json:"id"`
+		ClaimCmd   string `json:"claim_command"`
+	}
+	nextOut := run("--robot-next", &next)
+	if !next.Actionable || next.ID != "READY-1" || !strings.Contains(next.ClaimCmd, "READY-1") {
+		t.Fatalf("robot-next selected non-ready work: %s", nextOut)
+	}
+
+	var triage struct {
+		Triage struct {
+			QuickRef struct {
+				TopPicks []analysis.TopPick `json:"top_picks"`
+			} `json:"quick_ref"`
+			Recommendations []analysis.Recommendation `json:"recommendations"`
+		} `json:"triage"`
+	}
+	triageOut := run("--robot-triage", &triage)
+	if len(triage.Triage.QuickRef.TopPicks) == 0 || triage.Triage.QuickRef.TopPicks[0].ID != "READY-1" {
+		t.Fatalf("robot-triage did not lead with READY-1: %s", triageOut)
+	}
+	for _, pick := range triage.Triage.QuickRef.TopPicks {
+		switch pick.ID {
+		case "FUTURE-1", "CLOSED-1", "TOMBSTONE-1":
+			t.Fatalf("robot-triage leaked non-ready pick %s: %s", pick.ID, triageOut)
+		}
+	}
+	for _, rec := range triage.Triage.Recommendations {
+		if rec.ID == "FUTURE-1" && (!strings.Contains(rec.Action, "Wait until") || strings.Contains(strings.Join(rec.Reasons, " "), "available for work")) {
+			t.Fatalf("robot-triage described future-deferred work as ready: %#v", rec)
+		}
+	}
+}
+
 func TestRobotNextClaimablePickRejectsAssignedTopPick(t *testing.T) {
 	picks := []analysis.TopPick{{
 		ID:    "ASSIGNED-1",
@@ -238,7 +306,7 @@ func TestRobotNextClaimablePickRejectsAssignedTopPick(t *testing.T) {
 		Assignee:  " cc11 ",
 	}}
 
-	_, diagnostic, reasons, ok := robotNextClaimablePick(picks, issues)
+	_, diagnostic, reasons, ok := robotNextClaimablePick(picks, issues, time.Time{})
 	if ok {
 		t.Fatalf("assigned top pick must not be claimable")
 	}

--- a/cmd/bv/robot_registry.go
+++ b/cmd/bv/robot_registry.go
@@ -2033,7 +2033,7 @@ func robotNextIssueIndex(issues []model.Issue) map[string]model.Issue {
 	return issueByID
 }
 
-func robotNextClaimabilityReasons(pick analysis.TopPick, issueByID map[string]model.Issue) []string {
+func robotNextClaimabilityReasons(pick analysis.TopPick, issueByID map[string]model.Issue, now time.Time) []string {
 	issue, ok := issueByID[pick.ID]
 	if !ok {
 		return []string{fmt.Sprintf("%s is absent from loaded Beads records", pick.ID)}
@@ -2048,6 +2048,9 @@ func robotNextClaimabilityReasons(pick analysis.TopPick, issueByID map[string]mo
 	}
 	if assignee := strings.TrimSpace(issue.Assignee); assignee != "" {
 		reasons = append(reasons, fmt.Sprintf("%s is already assigned to %s", pick.ID, assignee))
+	}
+	if issue.IsDeferredAt(now) {
+		reasons = append(reasons, fmt.Sprintf("%s is deferred until %s", pick.ID, issue.DeferUntil.UTC().Format(time.RFC3339)))
 	}
 
 	var openBlockers []string
@@ -2087,7 +2090,7 @@ func robotNextDiagnosticFromPick(pick analysis.TopPick) robotNextDiagnosticPick 
 	}
 }
 
-func robotNextClaimablePick(picks []analysis.TopPick, issues []model.Issue) (analysis.TopPick, *robotNextDiagnosticPick, []string, bool) {
+func robotNextClaimablePick(picks []analysis.TopPick, issues []model.Issue, now time.Time) (analysis.TopPick, *robotNextDiagnosticPick, []string, bool) {
 	if len(picks) == 0 {
 		return analysis.TopPick{}, nil, nil, false
 	}
@@ -2096,7 +2099,7 @@ func robotNextClaimablePick(picks []analysis.TopPick, issues []model.Issue) (ana
 	firstDiagnostic := robotNextDiagnosticFromPick(picks[0])
 	var firstUnsafeReasons []string
 	for _, pick := range picks {
-		reasons := robotNextClaimabilityReasons(pick, issueByID)
+		reasons := robotNextClaimabilityReasons(pick, issueByID, now)
 		if len(reasons) == 0 {
 			return pick, &firstDiagnostic, nil, true
 		}
@@ -2150,7 +2153,7 @@ func handleRobotNext(ctx RobotContext, cfg phaseThreeRobotHandlerConfig) error {
 		return nil
 	}
 
-	top, diagnostic, unsafePickReasons, ok := robotNextClaimablePick(triage.QuickRef.TopPicks, ctx.Issues)
+	top, diagnostic, unsafePickReasons, ok := robotNextClaimablePick(triage.QuickRef.TopPicks, ctx.Issues, now)
 	if !ok {
 		output.Message = "No claim command emitted because the top recommendation was not claim-safe"
 		output.DiagnosticTopPick = diagnostic

--- a/internal/datasource/reader_test.go
+++ b/internal/datasource/reader_test.go
@@ -285,6 +285,26 @@ func TestSQLiteReader_EscapesURIControlCharsInPath(t *testing.T) {
 	}
 }
 
+func TestSQLiteReader_LoadsDeferUntil(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "defer-until.db")
+	createContractTestSQLiteDB(t, dbPath)
+
+	r, err := NewSQLiteReader(DataSource{Type: SourceTypeSQLite, Path: dbPath})
+	if err != nil {
+		t.Fatalf("NewSQLiteReader: %v", err)
+	}
+	defer r.Close()
+
+	issue, err := r.GetIssueByID("CTR-1")
+	if err != nil {
+		t.Fatalf("GetIssueByID: %v", err)
+	}
+	want := time.Date(2026, 9, 15, 16, 0, 0, 0, time.UTC)
+	if issue.DeferUntil == nil || !issue.DeferUntil.Equal(want) {
+		t.Fatalf("defer_until = %v, want %v", issue.DeferUntil, want)
+	}
+}
+
 func TestSQLiteReader_FallbackSchemaLoadsGraphMetadata(t *testing.T) {
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "export.db")
@@ -306,6 +326,7 @@ func TestSQLiteReader_FallbackSchemaLoadsGraphMetadata(t *testing.T) {
 			labels TEXT,
 			created_at TEXT NOT NULL,
 			updated_at TEXT NOT NULL,
+			defer_until TEXT,
 			closed_at TEXT
 		);
 		CREATE TABLE dependencies (
@@ -321,8 +342,8 @@ func TestSQLiteReader_FallbackSchemaLoadsGraphMetadata(t *testing.T) {
 			text TEXT NOT NULL,
 			created_at TEXT NOT NULL
 		);
-		INSERT INTO issues (id, title, description, status, priority, issue_type, assignee, labels, created_at, updated_at)
-		VALUES ('EXP-1', 'Export issue', 'from export schema', 'open', 1, 'task', 'cc11', '["graph","sqlite"]', ?, ?);
+		INSERT INTO issues (id, title, description, status, priority, issue_type, assignee, labels, created_at, updated_at, defer_until)
+		VALUES ('EXP-1', 'Export issue', 'from export schema', 'open', 1, 'task', 'cc11', '["graph","sqlite"]', ?, ?, '2026-09-15T16:00:00Z');
 		INSERT INTO issues (id, title, description, status, priority, issue_type, assignee, labels, created_at, updated_at)
 		VALUES ('ROOT-1', 'Root issue', '', 'open', 2, 'task', '', '[]', ?, ?);
 		INSERT INTO dependencies (issue_id, depends_on_id, type)
@@ -352,6 +373,9 @@ func TestSQLiteReader_FallbackSchemaLoadsGraphMetadata(t *testing.T) {
 	}
 	if issue.Assignee != "cc11" {
 		t.Fatalf("expected assignee from fallback schema, got %q", issue.Assignee)
+	}
+	if issue.DeferUntil == nil || issue.DeferUntil.Format(time.RFC3339) != "2026-09-15T16:00:00Z" {
+		t.Fatalf("expected defer_until from fallback schema, got %v", issue.DeferUntil)
 	}
 	if len(issue.Dependencies) != 1 {
 		t.Fatalf("expected one dependency from fallback schema, got %#v", issue.Dependencies)
@@ -390,6 +414,7 @@ func createContractTestSQLiteDB(t *testing.T, path string) {
 			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
 			updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
 			due_date DATETIME,
+			defer_until DATETIME,
 			closed_at DATETIME,
 			external_ref TEXT,
 			compaction_level INTEGER DEFAULT 0,
@@ -422,10 +447,10 @@ func createContractTestSQLiteDB(t *testing.T, path string) {
 
 	now := time.Now().UTC().Format(time.RFC3339Nano)
 	_, err = db.Exec(`
-		INSERT INTO issues (id, title, status, issue_type, updated_at) VALUES
-		('CTR-1', 'First issue',  'open',   'task', ?),
-		('CTR-2', 'Second issue', 'open',   'task', ?),
-		('CTR-3', 'Third issue',  'closed', 'task', ?)
+		INSERT INTO issues (id, title, status, issue_type, updated_at, defer_until) VALUES
+		('CTR-1', 'First issue',  'open',   'task', ?, '2026-09-15T16:00:00Z'),
+		('CTR-2', 'Second issue', 'open',   'task', ?, NULL),
+		('CTR-3', 'Third issue',  'closed', 'task', ?, NULL)
 	`, now, now, now)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/datasource/sqlite.go
+++ b/internal/datasource/sqlite.go
@@ -150,6 +150,12 @@ func (r *SQLiteReader) LoadIssues() ([]model.Issue, error) {
 
 // LoadIssuesFiltered reads issues matching the filter function
 func (r *SQLiteReader) LoadIssuesFiltered(filter func(*model.Issue) bool) ([]model.Issue, error) {
+	columns := r.issuesColumns()
+	deferUntilExpr := "NULL"
+	if columns["defer_until"] {
+		deferUntilExpr = "i.defer_until"
+	}
+
 	// Detect schema: beads-rs (br) databases store labels in a separate
 	// "labels" table rather than a JSON column on "issues". We substitute
 	// a subquery so that labels are loaded transparently.
@@ -164,13 +170,13 @@ func (r *SQLiteReader) LoadIssuesFiltered(filter func(*model.Issue) bool) ([]mod
 		SELECT
 			i.id, i.title, i.description, i.status, i.priority, i.issue_type,
 			i.assignee, i.estimated_minutes, i.created_at, i.updated_at,
-			i.due_date, i.closed_at, i.external_ref, i.compaction_level,
+			i.due_date, %s, i.closed_at, i.external_ref, i.compaction_level,
 			i.compacted_at, i.compacted_at_commit, i.original_size,
 			%s, i.design, i.acceptance_criteria, i.notes, i.source_repo
 		FROM issues i
 		WHERE (i.tombstone IS NULL OR i.tombstone = 0)
 		ORDER BY i.updated_at DESC
-	`, labelsExpr)
+	`, deferUntilExpr, labelsExpr)
 
 	rows, err := r.db.Query(query)
 	if err != nil {
@@ -183,7 +189,7 @@ func (r *SQLiteReader) LoadIssuesFiltered(filter func(*model.Issue) bool) ([]mod
 	for rows.Next() {
 		var issue model.Issue
 		var estimatedMinutes, compactionLevel, originalSize sql.NullInt64
-		var createdAt, updatedAt, dueDate, closedAt, compactedAt sql.NullTime
+		var createdAt, updatedAt, dueDate, deferUntil, closedAt, compactedAt sql.NullTime
 		var description, assignee, externalRef, design, acceptanceCriteria, notes, sourceRepo, compactedAtCommit sql.NullString
 		var labelsJSON sql.NullString
 		var issueType string
@@ -191,7 +197,7 @@ func (r *SQLiteReader) LoadIssuesFiltered(filter func(*model.Issue) bool) ([]mod
 		err := rows.Scan(
 			&issue.ID, &issue.Title, &description, &issue.Status, &issue.Priority, &issueType,
 			&assignee, &estimatedMinutes, &createdAt, &updatedAt,
-			&dueDate, &closedAt, &externalRef, &compactionLevel,
+			&dueDate, &deferUntil, &closedAt, &externalRef, &compactionLevel,
 			&compactedAt, &compactedAtCommit, &originalSize,
 			&labelsJSON, &design, &acceptanceCriteria, &notes, &sourceRepo,
 		)
@@ -220,6 +226,10 @@ func (r *SQLiteReader) LoadIssuesFiltered(filter func(*model.Issue) bool) ([]mod
 		if dueDate.Valid {
 			t := dueDate.Time
 			issue.DueDate = &t
+		}
+		if deferUntil.Valid {
+			t := deferUntil.Time
+			issue.DeferUntil = &t
 		}
 		if closedAt.Valid {
 			t := closedAt.Time
@@ -306,7 +316,7 @@ func (r *SQLiteReader) loadIssuesSimple(filter func(*model.Issue) bool) ([]model
 		orderBy = "ORDER BY updated_at DESC"
 	}
 	query := fmt.Sprintf(`
-		SELECT id, title, %s, status, %s, %s, %s, %s, %s, %s
+		SELECT id, title, %s, status, %s, %s, %s, %s, %s, %s, %s
 		FROM issues
 		%s
 		%s
@@ -317,6 +327,7 @@ func (r *SQLiteReader) loadIssuesSimple(filter func(*model.Issue) bool) ([]model
 		expr("assignee", "NULL"),
 		expr("created_at", "NULL"),
 		expr("updated_at", "NULL"),
+		expr("defer_until", "NULL"),
 		expr("labels", "NULL"),
 		where,
 		orderBy,
@@ -335,13 +346,13 @@ func (r *SQLiteReader) loadIssuesSimple(filter func(*model.Issue) bool) ([]model
 	for rows.Next() {
 		var issue model.Issue
 		var description, assignee sql.NullString
-		var createdAt, updatedAt sql.NullString
+		var createdAt, updatedAt, deferUntil sql.NullString
 		var labelsJSON sql.NullString
 		var issueType string
 
 		err := rows.Scan(
 			&issue.ID, &issue.Title, &description, &issue.Status, &issue.Priority, &issueType,
-			&assignee, &createdAt, &updatedAt, &labelsJSON,
+			&assignee, &createdAt, &updatedAt, &deferUntil, &labelsJSON,
 		)
 		if err != nil {
 			continue
@@ -362,6 +373,11 @@ func (r *SQLiteReader) loadIssuesSimple(filter func(*model.Issue) bool) ([]model
 		if updatedAt.Valid {
 			if t, ok := parseSQLiteTime(updatedAt.String); ok {
 				issue.UpdatedAt = t
+			}
+		}
+		if deferUntil.Valid {
+			if t, ok := parseSQLiteTime(deferUntil.String); ok {
+				issue.DeferUntil = &t
 			}
 		}
 		if labelsJSON.Valid && labelsJSON.String != "" && labelsJSON.String != "null" {

--- a/pkg/analysis/triage.go
+++ b/pkg/analysis/triage.go
@@ -103,6 +103,7 @@ type Recommendation struct {
 	Assignee    string         `json:"assignee,omitempty"`
 	Priority    int            `json:"priority"`
 	Labels      []string       `json:"labels"`
+	DeferUntil  *time.Time     `json:"defer_until,omitempty"`
 	Score       float64        `json:"score"`
 	Breakdown   ScoreBreakdown `json:"breakdown"`
 	Action      string         `json:"action"` // Suggested next action (human-readable)
@@ -569,7 +570,7 @@ func ComputeTriageFromAnalyzer(analyzer *Analyzer, stats *GraphStats, issues []m
 	// So: build the recommendations against the full triageScores set
 	// first, slice to opts.TopN for the user-visible recommendations
 	// list, and feed the *unsliced* set into buildTopPicks.
-	allRecommendations := buildRecommendationsFromTriageScores(triageScores, triageCtx, len(triageScores))
+	allRecommendations := buildRecommendationsFromTriageScores(triageScores, triageCtx, len(triageScores), now)
 	recommendations := allRecommendations
 	if len(recommendations) > opts.TopN {
 		recommendations = recommendations[:opts.TopN]
@@ -590,7 +591,7 @@ func ComputeTriageFromAnalyzer(analyzer *Analyzer, stats *GraphStats, issues []m
 	// Build top picks for quick ref. Pass the full set so blocked
 	// high-priority items don't crowd genuine actionable work out of
 	// the picks (issue #146).
-	topPicks := buildTopPicks(allRecommendations, 3, opts.NotReadyLabels, parentsWithOpenChildren)
+	topPicks := buildTopPicks(allRecommendations, 3, now, opts.NotReadyLabels, parentsWithOpenChildren)
 
 	// Determine top issue for commands
 	topID := ""
@@ -605,10 +606,10 @@ func ComputeTriageFromAnalyzer(analyzer *Analyzer, stats *GraphStats, issues []m
 	var recsByTrack []TrackRecommendationGroup
 	var recsByLabel []LabelRecommendationGroup
 	if opts.GroupByTrack {
-		recsByTrack = buildRecommendationsByTrack(recommendations, analyzer, unblocksMap, opts.NotReadyLabels, parentsWithOpenChildren)
+		recsByTrack = buildRecommendationsByTrack(recommendations, analyzer, unblocksMap, now, opts.NotReadyLabels, parentsWithOpenChildren)
 	}
 	if opts.GroupByLabel {
-		recsByLabel = buildRecommendationsByLabel(recommendations, unblocksMap, opts.NotReadyLabels, parentsWithOpenChildren)
+		recsByLabel = buildRecommendationsByLabel(recommendations, unblocksMap, now, opts.NotReadyLabels, parentsWithOpenChildren)
 	}
 
 	// Calculate staleness if history is available
@@ -816,7 +817,7 @@ func computeCountsWithContext(issues []model.Issue, ctx *TriageContext) HealthCo
 
 // buildRecommendationsFromTriageScores creates recommendations using enhanced triage scores.
 // Uses TriageContext for cached blocker lookups (bv-k4az optimization).
-func buildRecommendationsFromTriageScores(scores []TriageScore, ctx *TriageContext, limit int) []Recommendation {
+func buildRecommendationsFromTriageScores(scores []TriageScore, ctx *TriageContext, limit int, now time.Time) []Recommendation {
 	if len(scores) > limit {
 		scores = scores[:limit]
 	}
@@ -832,7 +833,7 @@ func buildRecommendationsFromTriageScores(scores []TriageScore, ctx *TriageConte
 		}
 
 		// Generate reasons using the new logic (cached via TriageContext)
-		reasons := GenerateTriageReasonsForScore(score, ctx)
+		reasons := generateTriageReasonsForScoreAt(score, ctx, now)
 
 		// Get blocked by (cached via TriageContext)
 		blockedBy := ctx.OpenBlockers(score.IssueID)
@@ -845,6 +846,7 @@ func buildRecommendationsFromTriageScores(scores []TriageScore, ctx *TriageConte
 			Assignee:    issue.Assignee,
 			Priority:    score.Priority,
 			Labels:      issue.Labels,
+			DeferUntil:  issue.DeferUntil,
 			Score:       score.TriageScore,
 			Breakdown:   score.Breakdown,
 			Action:      reasons.ActionHint,
@@ -1048,10 +1050,10 @@ func buildBlockersToClearWithContext(ctx *TriageContext, unblocksMap map[string]
 // buildTopPicks creates condensed top picks from recommendations.
 // Only includes actionable (non-blocked) items since TopPicks are used
 // for "what should I work on next" queries (e.g., --robot-next).
-func buildTopPicks(recommendations []Recommendation, limit int, notReadyLabels []string, parentsWithOpenChildren map[string]bool) []TopPick {
+func buildTopPicks(recommendations []Recommendation, limit int, now time.Time, notReadyLabels []string, parentsWithOpenChildren map[string]bool) []TopPick {
 	picks := make([]TopPick, 0, limit)
 	for _, rec := range recommendations {
-		if !isClaimableRecommendation(rec, notReadyLabels, parentsWithOpenChildren) {
+		if !isClaimableRecommendation(rec, now, notReadyLabels, parentsWithOpenChildren) {
 			continue
 		}
 		picks = append(picks, TopPick{
@@ -1082,7 +1084,7 @@ func buildTopPicks(recommendations []Recommendation, limit int, notReadyLabels [
 // notReadyLabels may be empty (the default), in which case the label gate is a
 // no-op. parentsWithOpenChildren may be nil, in which case the parent gate is
 // skipped (used by unit tests that exercise the predicate in isolation).
-func isClaimableRecommendation(rec Recommendation, notReadyLabels []string, parentsWithOpenChildren map[string]bool) bool {
+func isClaimableRecommendation(rec Recommendation, now time.Time, notReadyLabels []string, parentsWithOpenChildren map[string]bool) bool {
 	if parentsWithOpenChildren[rec.ID] {
 		return false
 	}
@@ -1090,6 +1092,7 @@ func isClaimableRecommendation(rec Recommendation, notReadyLabels []string, pare
 		rec.Type != string(model.TypeEpic) &&
 		rec.Assignee == "" &&
 		len(rec.BlockedBy) == 0 &&
+		(rec.DeferUntil == nil || !rec.DeferUntil.After(now)) &&
 		!hasAnyLabel(rec.Labels, notReadyLabels)
 }
 
@@ -1418,10 +1421,17 @@ type TriageReasons struct {
 // GenerateTriageReasons creates actionable reasons for a triage recommendation
 // These are emoji-prefixed, human-readable explanations that tell agents what to DO
 func GenerateTriageReasons(ctx TriageReasonContext) TriageReasons {
+	return generateTriageReasonsAt(ctx, time.Now())
+}
+
+func generateTriageReasonsAt(ctx TriageReasonContext, now time.Time) TriageReasons {
 	var reasons []string
 	primary := ""
 	actionHint := "Start work on this issue"
-	if ctx.Issue != nil && ctx.Issue.Status == model.StatusInProgress {
+	isFutureDeferred := ctx.Issue != nil && ctx.Issue.IsDeferredAt(now)
+	if isFutureDeferred {
+		actionHint = fmt.Sprintf("Wait until %s before claiming", ctx.Issue.DeferUntil.UTC().Format(time.RFC3339))
+	} else if ctx.Issue != nil && ctx.Issue.Status == model.StatusInProgress {
 		actionHint = "Continue work on this issue"
 	} else if ctx.Issue != nil && ctx.Issue.Status == model.StatusBlocked {
 		actionHint = "Resolve blocked status before claiming this issue"
@@ -1496,7 +1506,7 @@ func GenerateTriageReasons(ctx TriageReasonContext) TriageReasons {
 		// Update action hint unless in-progress (keep work/review guidance) or critically stale
 		isInProgress := ctx.Issue != nil && ctx.Issue.Status == model.StatusInProgress
 		isCriticalStale := isInProgress && ctx.DaysSinceUpdate > 14
-		if !isInProgress && !isCriticalStale {
+		if !isInProgress && !isCriticalStale && !isFutureDeferred {
 			actionHint = "Quick win - start here for fast progress"
 		}
 	}
@@ -1528,7 +1538,12 @@ func GenerateTriageReasons(ctx TriageReasonContext) TriageReasons {
 		!isInProgress &&
 		!isBlockedStatus &&
 		!isOpenStatus
-	if isInProgress {
+	if isFutureDeferred {
+		reasons = append(reasons, fmt.Sprintf("⏸️ Deferred until %s - not ready to claim", ctx.Issue.DeferUntil.UTC().Format(time.RFC3339)))
+		if ctx.ClaimedByAgent != "" {
+			reasons = append(reasons, fmt.Sprintf("👤 Claimed by %s", ctx.ClaimedByAgent))
+		}
+	} else if isInProgress {
 		if ctx.ClaimedByAgent != "" {
 			reason := fmt.Sprintf("👤 Claimed by %s", ctx.ClaimedByAgent)
 			reasons = append(reasons, reason)
@@ -1612,6 +1627,10 @@ func formatUnblockList(ids []string) string {
 // GenerateTriageReasonsForScore generates reasons from a TriageScore and TriageContext.
 // Uses cached blocker lookups for better performance (bv-k4az optimization).
 func GenerateTriageReasonsForScore(score TriageScore, triageCtx *TriageContext) TriageReasons {
+	return generateTriageReasonsForScoreAt(score, triageCtx, time.Now())
+}
+
+func generateTriageReasonsForScoreAt(score TriageScore, triageCtx *TriageContext, now time.Time) TriageReasons {
 	analyzer := triageCtx.Analyzer()
 	unblocksMap := triageCtx.UnblocksMap()
 	issue := analyzer.GetIssue(score.IssueID)
@@ -1639,7 +1658,7 @@ func GenerateTriageReasonsForScore(score TriageScore, triageCtx *TriageContext) 
 		BlockerDepth:    triageCtx.BlockerDepth(score.IssueID), // cached
 	}
 
-	return GenerateTriageReasons(ctx)
+	return generateTriageReasonsAt(ctx, now)
 }
 
 // EnhanceRecommendationWithTriageReasons updates a Recommendation with triage-specific reasons
@@ -1661,7 +1680,7 @@ func EnhanceRecommendationWithTriageReasons(rec *Recommendation, triageReasons T
 //
 // This differs from the previous connected-components approach which created
 // one track per disconnected work stream (issue #68).
-func buildRecommendationsByTrack(recs []Recommendation, analyzer *Analyzer, unblocksMap map[string][]string, notReadyLabels []string, parentsWithOpenChildren map[string]bool) []TrackRecommendationGroup {
+func buildRecommendationsByTrack(recs []Recommendation, analyzer *Analyzer, unblocksMap map[string][]string, now time.Time, notReadyLabels []string, parentsWithOpenChildren map[string]bool) []TrackRecommendationGroup {
 	// Compute blocker depth for all recommendations.
 	// Depth 0 = actionable now (no blockers), Depth N = blocked by depth-(N-1) items.
 	blockerDepths := make(map[string]int, len(recs))
@@ -1737,7 +1756,7 @@ func buildRecommendationsByTrack(recs []Recommendation, analyzer *Analyzer, unbl
 		group.TotalUnblocks += len(unblocksMap[rec.ID])
 
 		// Update top pick (highest score in this layer)
-		if isClaimableRecommendation(rec, notReadyLabels, parentsWithOpenChildren) && (group.TopPick == nil || rec.Score > group.TopPick.Score) {
+		if isClaimableRecommendation(rec, now, notReadyLabels, parentsWithOpenChildren) && (group.TopPick == nil || rec.Score > group.TopPick.Score) {
 			group.TopPick = &TopPick{
 				ID:       rec.ID,
 				Title:    rec.Title,
@@ -1779,7 +1798,7 @@ func layerReason(depth int, totalRecs int) string {
 }
 
 // buildRecommendationsByLabel groups recommendations by label
-func buildRecommendationsByLabel(recs []Recommendation, unblocksMap map[string][]string, notReadyLabels []string, parentsWithOpenChildren map[string]bool) []LabelRecommendationGroup {
+func buildRecommendationsByLabel(recs []Recommendation, unblocksMap map[string][]string, now time.Time, notReadyLabels []string, parentsWithOpenChildren map[string]bool) []LabelRecommendationGroup {
 	groups := make(map[string]*LabelRecommendationGroup)
 
 	for _, rec := range recs {
@@ -1797,7 +1816,7 @@ func buildRecommendationsByLabel(recs []Recommendation, unblocksMap map[string][
 		group.Recommendations = append(group.Recommendations, rec)
 		group.TotalUnblocks += len(unblocksMap[rec.ID])
 
-		if isClaimableRecommendation(rec, notReadyLabels, parentsWithOpenChildren) && (group.TopPick == nil || rec.Score > group.TopPick.Score) {
+		if isClaimableRecommendation(rec, now, notReadyLabels, parentsWithOpenChildren) && (group.TopPick == nil || rec.Score > group.TopPick.Score) {
 			group.TopPick = &TopPick{
 				ID:       rec.ID,
 				Title:    rec.Title,

--- a/pkg/analysis/triage_test.go
+++ b/pkg/analysis/triage_test.go
@@ -1396,7 +1396,7 @@ func TestTriageGroupByTrack_SingleTrack(t *testing.T) {
 		totalRecs += len(g.Recommendations)
 		hasClaimableRec := false
 		for _, rec := range g.Recommendations {
-			if isClaimableRecommendation(rec, nil, nil) {
+			if isClaimableRecommendation(rec, time.Time{}, nil, nil) {
 				hasClaimableRec = true
 				break
 			}
@@ -1563,7 +1563,7 @@ func TestTriageGroupByTrack_TopPickHasHighestScore(t *testing.T) {
 		}
 		// Top pick should have the highest score in the group
 		for _, rec := range g.Recommendations {
-			if !isClaimableRecommendation(rec, nil, nil) {
+			if !isClaimableRecommendation(rec, time.Time{}, nil, nil) {
 				continue
 			}
 			if rec.Score > g.TopPick.Score {
@@ -1724,7 +1724,7 @@ func TestBuildTopPicks_FiltersBlockedItems(t *testing.T) {
 	}
 
 	// Test with limit of 3
-	picks := buildTopPicks(recommendations, 3, nil, nil)
+	picks := buildTopPicks(recommendations, 3, time.Time{}, nil, nil)
 
 	// Should have exactly 3 picks (all actionable items)
 	if len(picks) != 3 {
@@ -1885,7 +1885,7 @@ func TestBuildTopPicks_LimitRespected(t *testing.T) {
 	}
 
 	// Limit of 2
-	picks := buildTopPicks(recommendations, 2, nil, nil)
+	picks := buildTopPicks(recommendations, 2, time.Time{}, nil, nil)
 	if len(picks) != 2 {
 		t.Errorf("expected 2 picks with limit=2, got %d", len(picks))
 	}
@@ -1903,7 +1903,7 @@ func TestBuildTopPicks_AllBlocked(t *testing.T) {
 		{ID: "b2", Title: "Blocked 2", Status: string(model.StatusOpen), Score: 90.0, BlockedBy: []string{"y"}},
 	}
 
-	picks := buildTopPicks(recommendations, 10, nil, nil)
+	picks := buildTopPicks(recommendations, 10, time.Time{}, nil, nil)
 	if len(picks) != 0 {
 		t.Errorf("expected 0 picks when all are blocked, got %d", len(picks))
 	}
@@ -1941,7 +1941,7 @@ func TestBuildTopPicks_SkipsBlockedStatusAndAssigned(t *testing.T) {
 		},
 	}
 
-	picks := buildTopPicks(recommendations, 3, nil, nil)
+	picks := buildTopPicks(recommendations, 3, time.Time{}, nil, nil)
 	if len(picks) != 1 {
 		t.Fatalf("expected only the claimable open issue, got %d picks: %#v", len(picks), picks)
 	}
@@ -1996,6 +1996,62 @@ func TestComputeTriage_NotReadyLabelExcludedFromTopPicks(t *testing.T) {
 	for _, pick := range got.QuickRef.TopPicks {
 		if pick.ID == "RAW-1" {
 			t.Fatalf("RAW-1 (needs-polish) must not appear in claimable top picks")
+		}
+	}
+}
+
+func TestComputeTriage_FutureDeferUntilExcludedFromClaimablePicks(t *testing.T) {
+	now := time.Date(2026, 8, 21, 7, 0, 0, 0, time.UTC)
+	future := now.Add(30 * 24 * time.Hour)
+	expired := now.Add(-time.Second)
+	issues := []model.Issue{
+		{ID: "FUTURE-1", Title: "Deferred by scheduler", Status: model.StatusOpen, Priority: 0, IssueType: model.TypeTask, DeferUntil: &future, Labels: []string{"lane"}, UpdatedAt: now},
+		{ID: "EXPIRED-1", Title: "Defer elapsed", Status: model.StatusOpen, Priority: 1, IssueType: model.TypeTask, DeferUntil: &expired, Labels: []string{"lane"}, UpdatedAt: now},
+		{ID: "READY-1", Title: "Ready work", Status: model.StatusOpen, Priority: 4, IssueType: model.TypeTask, Labels: []string{"lane"}, UpdatedAt: now},
+		{ID: "CLOSED-1", Title: "Closed work", Status: model.StatusClosed, Priority: 0, IssueType: model.TypeTask, UpdatedAt: now},
+		{ID: "TOMBSTONE-1", Title: "Deleted work", Status: model.StatusTombstone, Priority: 0, IssueType: model.TypeTask, UpdatedAt: now},
+	}
+
+	triage := ComputeTriageWithOptionsAndTime(issues, TriageOptions{
+		WaitForPhase2: true,
+		GroupByTrack:  true,
+		GroupByLabel:  true,
+	}, now)
+	want := map[string]bool{"EXPIRED-1": false, "READY-1": false}
+	for _, pick := range triage.QuickRef.TopPicks {
+		if pick.ID == "FUTURE-1" || pick.ID == "CLOSED-1" || pick.ID == "TOMBSTONE-1" {
+			t.Fatalf("non-claimable issue leaked into top_picks: %#v", pick)
+		}
+		if _, ok := want[pick.ID]; ok {
+			want[pick.ID] = true
+		}
+	}
+	for id, found := range want {
+		if !found {
+			t.Fatalf("expected %s in top_picks, got %#v", id, triage.QuickRef.TopPicks)
+		}
+	}
+	for _, group := range triage.RecommendationsByTrack {
+		if group.TopPick != nil && group.TopPick.ID == "FUTURE-1" {
+			t.Fatalf("future-deferred issue leaked into track top pick: %#v", group)
+		}
+	}
+	for _, group := range triage.RecommendationsByLabel {
+		if group.TopPick != nil && group.TopPick.ID == "FUTURE-1" {
+			t.Fatalf("future-deferred issue leaked into label top pick: %#v", group)
+		}
+	}
+	for _, rec := range triage.Recommendations {
+		if rec.ID != "FUTURE-1" {
+			continue
+		}
+		if !contains(rec.Action, "Wait until 2026-09-20T07:00:00Z") {
+			t.Fatalf("future-deferred action = %q, want wait guidance", rec.Action)
+		}
+		for _, reason := range rec.Reasons {
+			if contains(reason, "available for work") {
+				t.Fatalf("future-deferred recommendation claims availability: %v", rec.Reasons)
+			}
 		}
 	}
 }

--- a/pkg/loader/loader_test.go
+++ b/pkg/loader/loader_test.go
@@ -367,6 +367,7 @@ func TestIssuePoolResetsFields(t *testing.T) {
 	issue.Description = "desc"
 	issue.Assignee = "owner"
 	issue.DueDate = &now
+	issue.DeferUntil = &now
 	issue.ClosedAt = &now
 	issue.EstimatedMinutes = new(int)
 	*issue.EstimatedMinutes = 42
@@ -383,8 +384,8 @@ func TestIssuePoolResetsFields(t *testing.T) {
 	if reset.ID != "" || reset.Title != "" || reset.Description != "" || reset.Assignee != "" {
 		t.Fatalf("expected scalar fields to be cleared, got ID=%q title=%q desc=%q assignee=%q", reset.ID, reset.Title, reset.Description, reset.Assignee)
 	}
-	if reset.DueDate != nil || reset.ClosedAt != nil || reset.EstimatedMinutes != nil || reset.ExternalRef != nil {
-		t.Fatalf("expected pointer fields to be nil: due=%v closed=%v est=%v ext=%v", reset.DueDate, reset.ClosedAt, reset.EstimatedMinutes, reset.ExternalRef)
+	if reset.DueDate != nil || reset.DeferUntil != nil || reset.ClosedAt != nil || reset.EstimatedMinutes != nil || reset.ExternalRef != nil {
+		t.Fatalf("expected pointer fields to be nil: due=%v defer=%v closed=%v est=%v ext=%v", reset.DueDate, reset.DeferUntil, reset.ClosedAt, reset.EstimatedMinutes, reset.ExternalRef)
 	}
 	if len(reset.Dependencies) != 0 {
 		t.Fatalf("expected dependencies to be reset, got %d", len(reset.Dependencies))

--- a/pkg/loader/pool.go
+++ b/pkg/loader/pool.go
@@ -122,6 +122,7 @@ func clearIssueReferences(issue *model.Issue) {
 	issue.Labels = issue.Labels[:0]
 
 	issue.DueDate = nil
+	issue.DeferUntil = nil
 	issue.ClosedAt = nil
 	issue.EstimatedMinutes = nil
 	issue.ExternalRef = nil

--- a/pkg/model/types.go
+++ b/pkg/model/types.go
@@ -24,6 +24,7 @@ type Issue struct {
 	CreatedAt          time.Time     `json:"created_at"`
 	UpdatedAt          time.Time     `json:"updated_at"`
 	DueDate            *time.Time    `json:"due_date,omitempty"`
+	DeferUntil         *time.Time    `json:"defer_until,omitempty"`
 	ClosedAt           *time.Time    `json:"closed_at,omitempty"`
 	ExternalRef        *string       `json:"external_ref,omitempty"`
 	CompactionLevel    int           `json:"compaction_level,omitempty"`
@@ -51,6 +52,10 @@ func (i Issue) Clone() Issue {
 	if i.DueDate != nil {
 		v := *i.DueDate
 		clone.DueDate = &v
+	}
+	if i.DeferUntil != nil {
+		v := *i.DeferUntil
+		clone.DeferUntil = &v
 	}
 	if i.ExternalRef != nil {
 		v := *i.ExternalRef
@@ -91,6 +96,13 @@ func (i Issue) Clone() Issue {
 	}
 
 	return clone
+}
+
+// IsDeferredAt reports whether the issue is scheduler-deferred past now.
+// A defer_until timestamp at or before now has expired and does not withhold
+// otherwise-ready work.
+func (i Issue) IsDeferredAt(now time.Time) bool {
+	return i.DeferUntil != nil && i.DeferUntil.After(now)
 }
 
 // Validate checks if the issue data is logically valid

--- a/pkg/model/types_test.go
+++ b/pkg/model/types_test.go
@@ -7,6 +7,32 @@ import (
 	"time"
 )
 
+func TestIssueDeferUntilJSONAndClone(t *testing.T) {
+	const raw = `{"id":"deferred-1","title":"Later","status":"open","issue_type":"task","defer_until":"2027-01-01T17:00:00Z"}`
+	var issue Issue
+	if err := json.Unmarshal([]byte(raw), &issue); err != nil {
+		t.Fatalf("unmarshal issue: %v", err)
+	}
+	want := time.Date(2027, 1, 1, 17, 0, 0, 0, time.UTC)
+	if issue.DeferUntil == nil || !issue.DeferUntil.Equal(want) {
+		t.Fatalf("defer_until = %v, want %v", issue.DeferUntil, want)
+	}
+	if !issue.IsDeferredAt(want.Add(-time.Second)) {
+		t.Fatal("future defer_until must be active")
+	}
+	if issue.IsDeferredAt(want) {
+		t.Fatal("defer_until at the current instant must be expired")
+	}
+
+	clone := issue.Clone()
+	if clone.DeferUntil == issue.DeferUntil {
+		t.Fatal("Clone must copy defer_until storage")
+	}
+	if clone.DeferUntil == nil || !clone.DeferUntil.Equal(want) {
+		t.Fatalf("clone defer_until = %v, want %v", clone.DeferUntil, want)
+	}
+}
+
 func TestStatus_IsValid(t *testing.T) {
 	tests := []struct {
 		name   string


### PR DESCRIPTION
## Summary

- preserve `defer_until` when loading Beads JSONL records
- exclude future-deferred issues from `--robot-next`, `--robot-triage` top picks, and track/label claim commands using the pinned robot clock
- keep elapsed deferrals eligible and give future-deferred full recommendations explicit wait guidance
- causally cover future deferrals plus closed/tombstone exclusions through both robot commands

## Verification

- `go test ./pkg/model ./pkg/analysis`
- `go test ./cmd/bv -run 'TestRobotCommandsExcludeFutureDeferredClosedAndTombstoneIssues|TestRobotNextClaimablePickRejectsAssignedTopPick' -count=1`\n- `go vet ./...`\n- `go build ./...`\n- `gofmt -l` on all changed files: clean\n- `git diff --check`: clean\n\nRepo-wide `go test ./...` completed with the changed packages and `tests/e2e` green. It remains red in unrelated existing surfaces: two `pkg/ui` GUI-editor environment tests and the timing-flaky `pkg/watcher` `TestDebouncer_CoalescesRapidTriggers`.\n\nTracks client-cmi infra bead `cmi-5uvb5`.