### PR TITLE
Add assignee and issue-type quick filters (A/I) to the list view

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ At its heart, `bv` is about **viewing your work nicely**.
 No web page loads, no heavy clients. `bv` starts instantly and lets you fly through your issue backlog using standard Vim keys (`j`/`k`).
 *   **Split-View Dashboard:** On wider screens, see your list on the left and full details on the right.
 *   **Markdown Rendering:** Issue descriptions, comments, and notes are beautifully rendered with syntax highlighting, headers, and lists.
-*   **Instant Filtering:** Zero-latency filtering. Press `o` for Open, `c` for Closed, or `r` for Ready (unblocked) tasks.
+*   **Instant Filtering:** Zero-latency filtering. Press `o` for Open, `c` for Closed, or `r` for Ready (unblocked) tasks. Press `A` to filter by assignee or `I` to filter by issue type—both compose with the status filter instead of replacing it, so `o` + `A` narrows to one assignee's open issues.
 *   **Live Reload:** Watches the active Beads JSONL file and refreshes lists, details, and insights automatically when the file changes—no restart needed.
 
 ### 🔎 Rich Context
@@ -3658,6 +3658,8 @@ bv has a comprehensive built-in help system:
 | | `/` | **Search** (Fuzzy) |
 | | `Ctrl+S` | Toggle **Search Mode** (Semantic ↔ Fuzzy) |
 | | `l` | **Label Picker** (quick filter by label) |
+| | `A` | **Assignee Picker** (quick filter by assignee) |
+| | `I` | **Type Picker** (quick filter by issue type) |
 | **List Sorting** | `s` | Cycle Sort Mode (Default → Created ↑ → Created ↓ → Priority → Updated) |
 | **Views** | `b` | Toggle **Kanban Board** |
 | | `i` | Toggle **Insights Dashboard** |
@@ -3694,6 +3696,8 @@ bv has a comprehensive built-in help system:
 | | `!` | Toggle **Alerts Panel** (proactive warnings) |
 | | `'` | Recipe Picker |
 | | `w` | Repo Picker (workspace mode) |
+
+> **Note:** The assignee and type filters (`A` / `I`) compose with the status filter (`o`/`c`/`r`/`a`) instead of replacing it—e.g. `o` then `A` → alice narrows to alice's open issues. The label filter (`l`) still replaces the status filter rather than composing with it.
 
 ---
 

--- a/pkg/correlation/head_artifact_cache.go
+++ b/pkg/correlation/head_artifact_cache.go
@@ -1,7 +1,6 @@
 package correlation
 
 import (
-	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -42,12 +41,12 @@ import (
 // (a pure read does not rewrite the file just to bump AccessedAt).
 
 const (
-	headArtifactCacheVersion      = 2
-	headArtifactCacheFileName     = "correlation_head_artifact_cache.json"
-	headArtifactCacheMaxEntries   = 6
-	headArtifactCacheMaxAge       = 24 * time.Hour
-	headArtifactCacheMaxEntrySize = 64 << 20 // 64MB serialized artifact ceiling
-	headArtifactCacheMaxFileSize int64 = headArtifactCacheMaxEntries*headArtifactCacheMaxEntrySize + (1 << 20)
+	headArtifactCacheVersion            = 2
+	headArtifactCacheFileName           = "correlation_head_artifact_cache.json"
+	headArtifactCacheMaxEntries         = 6
+	headArtifactCacheMaxAge             = 24 * time.Hour
+	headArtifactCacheMaxEntrySize       = 64 << 20 // 64MB serialized artifact ceiling
+	headArtifactCacheMaxFileSize  int64 = headArtifactCacheMaxEntries*headArtifactCacheMaxEntrySize + (1 << 20)
 )
 
 type headArtifactCacheFile struct {

--- a/pkg/correlation/network.go
+++ b/pkg/correlation/network.go
@@ -233,7 +233,6 @@ func (nb *NetworkBuilder) BuildAt(now time.Time) *ImpactNetwork {
 		return network.Edges[i].EdgeType < network.Edges[j].EdgeType
 	})
 
-
 	nb.recomputeNodeDegrees(network)
 
 	// Detect clusters using connected components with edge weight threshold
@@ -243,6 +242,20 @@ func (nb *NetworkBuilder) BuildAt(now time.Time) *ImpactNetwork {
 	nb.calculateStats(network)
 
 	return network
+}
+
+// recomputeNodeDegrees recalculates each node's Degree from the current edge
+// set. Called once edges are fully built (and sorted) so degree counts are
+// deterministic regardless of the order edges were discovered in.
+func (nb *NetworkBuilder) recomputeNodeDegrees(network *ImpactNetwork) {
+	for _, edge := range network.Edges {
+		if node, ok := network.Nodes[edge.FromBead]; ok {
+			node.Degree++
+		}
+		if node, ok := network.Nodes[edge.ToBead]; ok {
+			node.Degree++
+		}
+	}
 }
 
 func latestHistoryActivity(history BeadHistory) time.Time {
@@ -288,7 +301,6 @@ func (nb *NetworkBuilder) addSharedCommitEdges(network *ImpactNetwork) {
 		if len(beadIDs) < 2 {
 			continue
 		}
-
 
 		// A malformed or hand-built CommitIndex may repeat a bead ID. Normalize
 		// each membership list so a commit contributes once per distinct pair.

--- a/pkg/ui/context_help.go
+++ b/pkg/ui/context_help.go
@@ -102,6 +102,8 @@ const contextHelpList = `## List View
   o         Open issues only
   c         Closed issues only
   r         Ready (no blockers)
+  A         Filter by assignee
+  I         Filter by issue type
   /         Fuzzy search
   Ctrl+S    Semantic search (AI)
   H         Hybrid ranking
@@ -267,7 +269,11 @@ const contextHelpFilter = `## Filter Mode
   Esc       Clear search
 
 **Label Filters**
-  l         Open label picker`
+  l         Open label picker
+
+**Assignee/Type Filters**
+  A         Filter by assignee (combines with status)
+  I         Filter by issue type (combines with status)`
 
 const contextHelpLabelPicker = `## Label Picker
 

--- a/pkg/ui/coverage_extra_test.go
+++ b/pkg/ui/coverage_extra_test.go
@@ -1692,3 +1692,48 @@ func TestEditorExitMsgWithError(t *testing.T) {
 		t.Fatalf("expected editor error message, got %q", resultModel.statusMsg)
 	}
 }
+
+func TestExtractAssigneeCounts(t *testing.T) {
+	issues := []model.Issue{
+		{ID: "1", Assignee: "alice"},
+		{ID: "2", Assignee: "bob"},
+		{ID: "3", Assignee: "alice"},
+		{ID: "4", Assignee: ""},
+	}
+
+	names, counts := extractAssigneeCounts(issues)
+
+	if len(names) != 2 {
+		t.Fatalf("expected 2 distinct assignees, got %d (%v)", len(names), names)
+	}
+	if counts["alice"] != 2 {
+		t.Errorf("expected alice count 2, got %d", counts["alice"])
+	}
+	if counts["bob"] != 1 {
+		t.Errorf("expected bob count 1, got %d", counts["bob"])
+	}
+	if _, ok := counts[""]; ok {
+		t.Error("expected unassigned issues to be excluded from counts")
+	}
+}
+
+func TestExtractIssueTypeCounts(t *testing.T) {
+	issues := []model.Issue{
+		{ID: "1", IssueType: model.TypeBug},
+		{ID: "2", IssueType: model.TypeFeature},
+		{ID: "3", IssueType: model.TypeBug},
+		{ID: "4", IssueType: "molecule"}, // custom Gastown-style type
+	}
+
+	names, counts := extractIssueTypeCounts(issues)
+
+	if len(names) != 3 {
+		t.Fatalf("expected 3 distinct types, got %d (%v)", len(names), names)
+	}
+	if counts["bug"] != 2 {
+		t.Errorf("expected bug count 2, got %d", counts["bug"])
+	}
+	if counts["molecule"] != 1 {
+		t.Errorf("expected custom type 'molecule' to be counted, got %d", counts["molecule"])
+	}
+}

--- a/pkg/ui/keybindings.go
+++ b/pkg/ui/keybindings.go
@@ -313,6 +313,8 @@ func GetKeyBindingDocs() []KeyBindingDoc {
 		{"c", "Closed issues only", "Filters", "list"},
 		{"r", "Ready (unblocked)", "Filters", "list"},
 		{"l", "Label picker", "Filters", "list"},
+		{"A", "Assignee picker", "Filters", "list"},
+		{"I", "Issue type picker", "Filters", "list"},
 		{"/", "Search/filter", "Filters", "list"},
 
 		// Actions

--- a/pkg/ui/keybindings_test.go
+++ b/pkg/ui/keybindings_test.go
@@ -704,6 +704,170 @@ func TestKeyDispatch_Regression_LabelPickerConsumesQKey(t *testing.T) {
 	}
 }
 
+// testIssuesForAssigneeAndTypeDispatch mirrors testIssuesForKeyDispatch but
+// populates Assignee/IssueType so the pickers have real entries to select.
+func testIssuesForAssigneeAndTypeDispatch() []model.Issue {
+	return []model.Issue{
+		{ID: "kd-1", Title: "Test Issue 1", Status: model.StatusOpen, IssueType: model.TypeBug, Assignee: "alice"},
+		{ID: "kd-2", Title: "Test Issue 2", Status: model.StatusOpen, IssueType: model.TypeFeature, Assignee: "bob"},
+		{ID: "kd-3", Title: "Test Issue 3", Status: model.StatusClosed, IssueType: model.TypeBug, Assignee: "alice"},
+	}
+}
+
+// TestKeyDispatch_Regression_AssigneePickerConsumesQKey guards against the
+// same issue #176 class of bug as the label picker (see
+// TestKeyDispatch_Regression_LabelPickerConsumesQKey): the assignee picker
+// reuses the same always-focused text input, so a lowercase q must be typed
+// into the filter rather than triggering the global quit/back shortcut.
+func TestKeyDispatch_Regression_AssigneePickerConsumesQKey(t *testing.T) {
+	m := NewModel(testIssuesForAssigneeAndTypeDispatch(), nil, "")
+
+	updated, _ := m.Update(keyMsg("A"))
+	m = updated.(*Model)
+	if m.focused != focusAssigneePicker || !m.showAssigneePicker {
+		t.Fatalf("expected assignee picker after 'A', got focused=%v showAssigneePicker=%v", m.focused, m.showAssigneePicker)
+	}
+
+	updated, _ = m.Update(keyMsg("q"))
+	m = updated.(*Model)
+	if !m.showAssigneePicker || m.focused != focusAssigneePicker {
+		t.Fatalf("expected assignee picker to stay open after typing 'q', got focused=%v showAssigneePicker=%v", m.focused, m.showAssigneePicker)
+	}
+	if got := m.assigneePicker.InputValue(); got != "q" {
+		t.Fatalf("expected assignee filter input %q after typing 'q', got %q", "q", got)
+	}
+
+	updated, _ = m.Update(keyMsg("esc"))
+	m = updated.(*Model)
+	if m.showAssigneePicker || m.focused != focusList {
+		t.Fatalf("expected esc to cancel assignee picker, got focused=%v showAssigneePicker=%v", m.focused, m.showAssigneePicker)
+	}
+}
+
+// TestKeyDispatch_AssigneePickerEnterAppliesFilter verifies selecting an
+// assignee and pressing enter narrows the list to that assignee's issues.
+func TestKeyDispatch_AssigneePickerEnterAppliesFilter(t *testing.T) {
+	m := NewModel(testIssuesForAssigneeAndTypeDispatch(), nil, "")
+
+	updated, _ := m.Update(keyMsg("A"))
+	m = updated.(*Model)
+
+	for _, r := range "alice" {
+		updated, _ = m.Update(keyMsg(string(r)))
+		m = updated.(*Model)
+	}
+
+	updated, _ = m.Update(keyMsg("enter"))
+	m = updated.(*Model)
+
+	if m.showAssigneePicker || m.focused != focusList {
+		t.Fatalf("expected enter to close assignee picker and return to list, got focused=%v showAssigneePicker=%v", m.focused, m.showAssigneePicker)
+	}
+	if m.assigneeFilter != "alice" {
+		t.Fatalf("expected assigneeFilter %q, got %q", "alice", m.assigneeFilter)
+	}
+	for _, issue := range m.FilteredIssues() {
+		if issue.Assignee != "alice" {
+			t.Errorf("expected only alice's issues after filter, got assignee %q", issue.Assignee)
+		}
+	}
+}
+
+// TestKeyDispatch_Regression_TypePickerConsumesQKey mirrors the label/assignee
+// picker q-key regression above for the issue type picker.
+func TestKeyDispatch_Regression_TypePickerConsumesQKey(t *testing.T) {
+	m := NewModel(testIssuesForAssigneeAndTypeDispatch(), nil, "")
+
+	updated, _ := m.Update(keyMsg("I"))
+	m = updated.(*Model)
+	if m.focused != focusTypePicker || !m.showTypePicker {
+		t.Fatalf("expected type picker after 'I', got focused=%v showTypePicker=%v", m.focused, m.showTypePicker)
+	}
+
+	updated, _ = m.Update(keyMsg("q"))
+	m = updated.(*Model)
+	if !m.showTypePicker || m.focused != focusTypePicker {
+		t.Fatalf("expected type picker to stay open after typing 'q', got focused=%v showTypePicker=%v", m.focused, m.showTypePicker)
+	}
+	if got := m.typePicker.InputValue(); got != "q" {
+		t.Fatalf("expected type filter input %q after typing 'q', got %q", "q", got)
+	}
+
+	updated, _ = m.Update(keyMsg("esc"))
+	m = updated.(*Model)
+	if m.showTypePicker || m.focused != focusList {
+		t.Fatalf("expected esc to cancel type picker, got focused=%v showTypePicker=%v", m.focused, m.showTypePicker)
+	}
+}
+
+// TestKeyDispatch_TypePickerEnterAppliesFilter verifies selecting a type and
+// pressing enter narrows the list to that issue type.
+func TestKeyDispatch_TypePickerEnterAppliesFilter(t *testing.T) {
+	m := NewModel(testIssuesForAssigneeAndTypeDispatch(), nil, "")
+
+	updated, _ := m.Update(keyMsg("I"))
+	m = updated.(*Model)
+
+	for _, r := range "bug" {
+		updated, _ = m.Update(keyMsg(string(r)))
+		m = updated.(*Model)
+	}
+
+	updated, _ = m.Update(keyMsg("enter"))
+	m = updated.(*Model)
+
+	if m.showTypePicker || m.focused != focusList {
+		t.Fatalf("expected enter to close type picker and return to list, got focused=%v showTypePicker=%v", m.focused, m.showTypePicker)
+	}
+	if m.typeFilter != "bug" {
+		t.Fatalf("expected typeFilter %q, got %q", "bug", m.typeFilter)
+	}
+	for _, issue := range m.FilteredIssues() {
+		if issue.IssueType != model.TypeBug {
+			t.Errorf("expected only bug issues after filter, got type %q", issue.IssueType)
+		}
+	}
+}
+
+// TestKeyDispatch_Regression_AssigneeFilterComposesWithOpenClose guards
+// against the regression where opening the assignee/type picker and
+// selecting a value would silently discard an active "open"/"closed" status
+// filter instead of narrowing it further.
+func TestKeyDispatch_Regression_AssigneeFilterComposesWithOpenClose(t *testing.T) {
+	m := NewModel(testIssuesForAssigneeAndTypeDispatch(), nil, "")
+
+	// Apply the "open" status filter first (kd-3 is closed, so this should
+	// narrow to kd-1 and kd-2, both assigned to alice/bob respectively).
+	updated, _ := m.Update(keyMsg("o"))
+	m = updated.(*Model)
+	if m.currentFilter != "open" {
+		t.Fatalf("expected currentFilter %q after 'o', got %q", "open", m.currentFilter)
+	}
+
+	// Now layer an assignee filter on top via the picker.
+	updated, _ = m.Update(keyMsg("A"))
+	m = updated.(*Model)
+	for _, r := range "alice" {
+		updated, _ = m.Update(keyMsg(string(r)))
+		m = updated.(*Model)
+	}
+	updated, _ = m.Update(keyMsg("enter"))
+	m = updated.(*Model)
+
+	// The status filter must still be "open" (not clobbered by the picker),
+	// and the visible issues must satisfy BOTH constraints.
+	if m.currentFilter != "open" {
+		t.Fatalf("expected currentFilter to remain %q after applying assignee filter, got %q", "open", m.currentFilter)
+	}
+	if m.assigneeFilter != "alice" {
+		t.Fatalf("expected assigneeFilter %q, got %q", "alice", m.assigneeFilter)
+	}
+	filtered := m.FilteredIssues()
+	if len(filtered) != 1 || filtered[0].ID != "kd-1" {
+		t.Fatalf("expected only kd-1 (open, assigned to alice), got %#v", filtered)
+	}
+}
+
 func TestKeyDispatch_Regression_HistorySearchEnterKeepsFilter(t *testing.T) {
 	m := setupTestModel(t)
 

--- a/pkg/ui/label_picker.go
+++ b/pkg/ui/label_picker.go
@@ -10,7 +10,8 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
-// LabelPickerModel provides a fuzzy search popup for quick label filtering
+// LabelPickerModel provides a fuzzy search popup for quick filtering by an
+// arbitrary set of string values (labels, assignees, issue types, ...).
 type LabelPickerModel struct {
 	allLabels     []string
 	labelCounts   map[string]int // count of issues per label
@@ -20,6 +21,7 @@ type LabelPickerModel struct {
 	width         int
 	height        int
 	theme         Theme
+	title         string // overlay title; defaults to "Filter by Label" when empty
 }
 
 // NewLabelPickerModel creates a new label picker with fuzzy search
@@ -41,6 +43,14 @@ func NewLabelPickerModel(labels []string, counts map[string]int, theme Theme) La
 		selectedIndex: 0,
 		theme:         theme,
 	}
+}
+
+// NewPickerModel creates a fuzzy-search picker over an arbitrary set of
+// values with a custom overlay title (e.g. "Filter by Assignee").
+func NewPickerModel(values []string, counts map[string]int, theme Theme, title string) LabelPickerModel {
+	m := NewLabelPickerModel(values, counts, theme)
+	m.title = title
+	return m
 }
 
 // Focus activates the picker input and returns its initial cursor command.
@@ -254,7 +264,11 @@ func (m *LabelPickerModel) View() string {
 		Foreground(t.Primary).
 		Bold(true).
 		MarginBottom(1)
-	lines = append(lines, titleStyle.Render("Filter by Label"))
+	title := m.title
+	if title == "" {
+		title = "Filter by Label"
+	}
+	lines = append(lines, titleStyle.Render(title))
 	lines = append(lines, "")
 
 	// Search input

--- a/pkg/ui/model.go
+++ b/pkg/ui/model.go
@@ -5166,6 +5166,7 @@ func (m *Model) handleActionableKeys(msg tea.KeyMsg) *Model {
 // returns commands produced by the embedded text input (notably clipboard
 // paste commands) so the Bubble Tea runtime can execute them.
 func (m *Model) handleHistoryKeys(msg tea.KeyMsg) (*Model, tea.Cmd) {
+	var cmd tea.Cmd
 	// Handle search input when active (bv-nkrj)
 	if m.historyView.IsSearchActive() {
 		switch msg.String() {
@@ -5426,7 +5427,7 @@ func (m *Model) handleHistoryKeys(msg tea.KeyMsg) (*Model, tea.Cmd) {
 		m.isHistoryView = false
 		m.focused = focusList
 	}
-	return m, nil
+	return m, cmd
 }
 
 // getCommitURL returns the GitHub/GitLab commit URL for a SHA (bv-xf4p)

--- a/pkg/ui/model.go
+++ b/pkg/ui/model.go
@@ -64,12 +64,14 @@ const (
 	focusHistory
 	focusAttention
 	focusLabelPicker
-	focusSprint      // Sprint dashboard view (bv-161)
-	focusAgentPrompt // AGENTS.md integration prompt (bv-i8dk)
-	focusFlowMatrix  // Cross-label flow matrix view
-	focusTutorial    // Interactive tutorial (bv-8y31)
-	focusCassModal   // Cass session preview modal (bv-5bqh)
-	focusUpdateModal // Self-update modal (bv-182)
+	focusSprint         // Sprint dashboard view (bv-161)
+	focusAgentPrompt    // AGENTS.md integration prompt (bv-i8dk)
+	focusFlowMatrix     // Cross-label flow matrix view
+	focusTutorial       // Interactive tutorial (bv-8y31)
+	focusCassModal      // Cass session preview modal (bv-5bqh)
+	focusUpdateModal    // Self-update modal (bv-182)
+	focusAssigneePicker // Assignee filter picker
+	focusTypePicker     // Issue type filter picker
 )
 
 // embeddedTextInputTarget identifies one of the text inputs owned by Model.
@@ -82,6 +84,8 @@ const (
 	embeddedTextInputTimeTravel
 	embeddedTextInputLabelPicker
 	embeddedTextInputHistorySearch
+	embeddedTextInputAssigneePicker
+	embeddedTextInputTypePicker
 )
 
 // embeddedTextInputSession identifies one specific activation of an embedded
@@ -680,7 +684,12 @@ type Model struct {
 	historyLoadCommand           historyLoadCommandFactory
 
 	// Filter and sort state
-	currentFilter            string
+	currentFilter string
+	// assigneeFilter and typeFilter compose with currentFilter (status/label/
+	// recipe) instead of replacing it, so e.g. "open" + assignee "alice" shows
+	// only alice's open issues. Empty string means no constraint.
+	assigneeFilter           string
+	typeFilter               string
 	sortMode                 SortMode // bv-3ita: current sort mode
 	semanticSearchEnabled    bool
 	semanticIndexBuilding    bool
@@ -730,6 +739,16 @@ type Model struct {
 	// Label picker (bv-126)
 	showLabelPicker bool
 	labelPicker     LabelPickerModel
+
+	// Assignee picker (filter by assignee) - reuses LabelPickerModel's generic
+	// fuzzy-search overlay
+	showAssigneePicker bool
+	assigneePicker     LabelPickerModel
+
+	// Type picker (filter by issue type) - reuses LabelPickerModel's generic
+	// fuzzy-search overlay
+	showTypePicker bool
+	typePicker     LabelPickerModel
 
 	// Repo picker (workspace mode)
 	showRepoPicker bool
@@ -877,6 +896,40 @@ func extractLabelCounts(stats map[string]*analysis.LabelStats) map[string]int {
 		}
 	}
 	return counts
+}
+
+// extractAssigneeCounts returns the distinct assignees present in issues and
+// the number of issues assigned to each.
+func extractAssigneeCounts(issues []model.Issue) ([]string, map[string]int) {
+	counts := make(map[string]int)
+	for _, issue := range issues {
+		if issue.Assignee != "" {
+			counts[issue.Assignee]++
+		}
+	}
+	names := make([]string, 0, len(counts))
+	for name := range counts {
+		names = append(names, name)
+	}
+	return names, counts
+}
+
+// extractIssueTypeCounts returns the distinct issue types present in issues
+// and the number of issues of each type. Issue types are open-ended (custom
+// types beyond bug/feature/task/epic/chore are supported), so this derives
+// the set from the data rather than the known-type constants.
+func extractIssueTypeCounts(issues []model.Issue) ([]string, map[string]int) {
+	counts := make(map[string]int)
+	for _, issue := range issues {
+		if issue.IssueType != "" {
+			counts[string(issue.IssueType)]++
+		}
+	}
+	names := make([]string, 0, len(counts))
+	for name := range counts {
+		names = append(names, name)
+	}
+	return names, counts
 }
 
 // WorkspaceInfo contains workspace loading metadata for TUI display
@@ -1650,6 +1703,14 @@ func NewModel(issues []model.Issue, activeRecipe *recipe.Recipe, beadsPath strin
 	labelCounts := extractLabelCounts(labelExtraction.Stats)
 	labelPicker := NewLabelPickerModel(labelExtraction.Labels, labelCounts, theme)
 
+	// Initialize assignee picker (filter by assignee)
+	assigneeNames, assigneeCounts := extractAssigneeCounts(issues)
+	assigneePicker := NewPickerModel(assigneeNames, assigneeCounts, theme, "Filter by Assignee")
+
+	// Initialize issue type picker (filter by type)
+	typeNames, typeCounts := extractIssueTypeCounts(issues)
+	typePicker := NewPickerModel(typeNames, typeCounts, theme, "Filter by Type")
+
 	// Initialize time-travel input
 	ti := textinput.New()
 	ti.Placeholder = "HEAD~5, main, v1.0.0, 2024-01-01..."
@@ -1811,6 +1872,8 @@ func NewModel(issues []model.Issue, activeRecipe *recipe.Recipe, beadsPath strin
 		recipePicker:        recipePicker,
 		activeRecipe:        activeRecipe,
 		labelPicker:         labelPicker,
+		assigneePicker:      assigneePicker,
+		typePicker:          typePicker,
 		labelDrilldownCache: make(map[string][]model.Issue),
 		timeTravelInput:     ti,
 		statusMsg:           initialStatus,
@@ -1975,6 +2038,10 @@ func (m *Model) embeddedTextInputSessionIsActive(session embeddedTextInputSessio
 		return m.focused == focusTimeTravelInput && m.showTimeTravelPrompt && m.timeTravelInput.Focused()
 	case embeddedTextInputLabelPicker:
 		return m.focused == focusLabelPicker && m.showLabelPicker && m.labelPicker.input.Focused()
+	case embeddedTextInputAssigneePicker:
+		return m.focused == focusAssigneePicker && m.showAssigneePicker && m.assigneePicker.input.Focused()
+	case embeddedTextInputTypePicker:
+		return m.focused == focusTypePicker && m.showTypePicker && m.typePicker.input.Focused()
 	case embeddedTextInputHistorySearch:
 		return m.focused == focusHistory && m.isHistoryView &&
 			m.historyView.IsSearchActive() && m.historyView.searchInput.Focused()
@@ -2006,6 +2073,10 @@ func (m *Model) updateEmbeddedTextInput(msg embeddedTextInputMsg) tea.Cmd {
 		m.timeTravelInput, cmd = m.timeTravelInput.Update(msg.msg)
 	case embeddedTextInputLabelPicker:
 		cmd = m.labelPicker.UpdateInput(msg.msg)
+	case embeddedTextInputAssigneePicker:
+		cmd = m.assigneePicker.UpdateInput(msg.msg)
+	case embeddedTextInputTypePicker:
+		cmd = m.typePicker.UpdateInput(msg.msg)
 	case embeddedTextInputHistorySearch:
 		cmd = m.updateHistorySearchInput(msg.msg)
 	default:
@@ -2843,6 +2914,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		} else {
 			fastDefaultView := (m.currentFilter == "" || m.currentFilter == "all") &&
+				m.assigneeFilter == "" && m.typeFilter == "" &&
 				m.sortMode == SortDefault &&
 				(!m.workspaceMode || m.activeRepos == nil) &&
 				len(msg.Snapshot.listModelItems) == len(msg.Snapshot.ListItems) &&
@@ -2863,7 +2935,6 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 				filteredItems = make([]list.Item, 0, len(msg.Snapshot.ListItems))
 				filteredIssues = make([]model.Issue, 0, len(msg.Snapshot.ListItems))
-				filterNow := time.Now()
 
 				for _, item := range msg.Snapshot.ListItems {
 					issue := item.Issue
@@ -2876,26 +2947,12 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						}
 					}
 
-					include := false
-					switch m.currentFilter {
-					case "all":
-						include = true
-					case "open":
-						include = !isClosedLikeStatus(issue.Status)
-					case "closed":
-						include = isClosedLikeStatus(issue.Status)
-					case "ready":
-						include = isIssueReadyAt(issue, m.issueMap, filterNow)
-					default:
-						if strings.HasPrefix(m.currentFilter, "label:") {
-							label := strings.TrimPrefix(m.currentFilter, "label:")
-							for _, l := range issue.Labels {
-								if l == label {
-									include = true
-									break
-								}
-							}
-						}
+					include := m.matchesStatusOrLabelFilter(issue)
+					if include && m.assigneeFilter != "" && issue.Assignee != m.assigneeFilter {
+						include = false
+					}
+					if include && m.typeFilter != "" && string(issue.IssueType) != m.typeFilter {
+						include = false
 					}
 
 					if include {
@@ -4044,6 +4101,24 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m, inputCmd = m.handleLabelPickerKeys(msg)
 			return m, tea.Batch(inputCmd, m.pendingSemanticFilterCmd())
 		}
+		// Assignee and type pickers have the same always-focused text input as
+		// the label picker above, and need the same early interception.
+		if m.focused == focusAssigneePicker && m.showAssigneePicker {
+			if msg.String() == "ctrl+c" {
+				return m, m.quitCommand()
+			}
+			var inputCmd tea.Cmd
+			m, inputCmd = m.handleAssigneePickerKeys(msg)
+			return m, tea.Batch(inputCmd, m.pendingSemanticFilterCmd())
+		}
+		if m.focused == focusTypePicker && m.showTypePicker {
+			if msg.String() == "ctrl+c" {
+				return m, m.quitCommand()
+			}
+			var inputCmd tea.Cmd
+			m, inputCmd = m.handleTypePickerKeys(msg)
+			return m, tea.Batch(inputCmd, m.pendingSemanticFilterCmd())
+		}
 
 		// Handle keys when not filtering
 		if m.list.FilterState() != list.Filtering {
@@ -4684,6 +4759,40 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				focusCmd := m.beginEmbeddedTextInputSession(
 					embeddedTextInputLabelPicker,
 					m.labelPicker.Focus(),
+				)
+				return m, tea.Batch(focusCmd, m.pendingSemanticFilterCmd())
+
+			case "A":
+				// Open assignee picker for quick filter
+				if len(m.issues) == 0 {
+					return m, nil
+				}
+				assigneeNames, assigneeCounts := extractAssigneeCounts(m.issues)
+				m.assigneePicker.SetLabels(assigneeNames, assigneeCounts)
+				m.assigneePicker.Reset()
+				m.assigneePicker.SetSize(m.width, m.height-1)
+				m.showAssigneePicker = true
+				m.focused = focusAssigneePicker
+				focusCmd := m.beginEmbeddedTextInputSession(
+					embeddedTextInputAssigneePicker,
+					m.assigneePicker.Focus(),
+				)
+				return m, tea.Batch(focusCmd, m.pendingSemanticFilterCmd())
+
+			case "I":
+				// Open issue type picker for quick filter
+				if len(m.issues) == 0 {
+					return m, nil
+				}
+				typeNames, typeCounts := extractIssueTypeCounts(m.issues)
+				m.typePicker.SetLabels(typeNames, typeCounts)
+				m.typePicker.Reset()
+				m.typePicker.SetSize(m.width, m.height-1)
+				m.showTypePicker = true
+				m.focused = focusTypePicker
+				focusCmd := m.beginEmbeddedTextInputSession(
+					embeddedTextInputTypePicker,
+					m.typePicker.Focus(),
 				)
 				return m, tea.Batch(focusCmd, m.pendingSemanticFilterCmd())
 
@@ -5677,6 +5786,70 @@ func (m *Model) handleLabelPickerKeys(msg tea.KeyMsg) (*Model, tea.Cmd) {
 	return m, inputCmd
 }
 
+// handleAssigneePickerKeys handles keyboard input when the assignee picker is focused
+func (m *Model) handleAssigneePickerKeys(msg tea.KeyMsg) (*Model, tea.Cmd) {
+	var inputCmd tea.Cmd
+	switch msg.String() {
+	case "esc":
+		m.showAssigneePicker = false
+		m.assigneePicker.Blur()
+		m.endEmbeddedTextInputSession(embeddedTextInputAssigneePicker)
+		m.focused = focusList
+	case "j", "down", "ctrl+n":
+		m.assigneePicker.MoveDown()
+	case "k", "up", "ctrl+p":
+		m.assigneePicker.MoveUp()
+	case "enter":
+		if selected := m.assigneePicker.SelectedLabel(); selected != "" {
+			m.assigneeFilter = selected
+			m.applyFilter()
+			m.statusMsg = fmt.Sprintf("Filtered by assignee: %s", selected)
+			m.statusIsError = false
+		}
+		m.showAssigneePicker = false
+		m.assigneePicker.Blur()
+		m.endEmbeddedTextInputSession(embeddedTextInputAssigneePicker)
+		m.focused = focusList
+	default:
+		// Pass other keys to text input for fuzzy search
+		inputCmd = m.assigneePicker.UpdateInput(msg)
+		inputCmd = m.scopeEmbeddedTextInputCmd(embeddedTextInputAssigneePicker, inputCmd)
+	}
+	return m, inputCmd
+}
+
+// handleTypePickerKeys handles keyboard input when the issue type picker is focused
+func (m *Model) handleTypePickerKeys(msg tea.KeyMsg) (*Model, tea.Cmd) {
+	var inputCmd tea.Cmd
+	switch msg.String() {
+	case "esc":
+		m.showTypePicker = false
+		m.typePicker.Blur()
+		m.endEmbeddedTextInputSession(embeddedTextInputTypePicker)
+		m.focused = focusList
+	case "j", "down", "ctrl+n":
+		m.typePicker.MoveDown()
+	case "k", "up", "ctrl+p":
+		m.typePicker.MoveUp()
+	case "enter":
+		if selected := m.typePicker.SelectedLabel(); selected != "" {
+			m.typeFilter = selected
+			m.applyFilter()
+			m.statusMsg = fmt.Sprintf("Filtered by type: %s", selected)
+			m.statusIsError = false
+		}
+		m.showTypePicker = false
+		m.typePicker.Blur()
+		m.endEmbeddedTextInputSession(embeddedTextInputTypePicker)
+		m.focused = focusList
+	default:
+		// Pass other keys to text input for fuzzy search
+		inputCmd = m.typePicker.UpdateInput(msg)
+		inputCmd = m.scopeEmbeddedTextInputCmd(embeddedTextInputTypePicker, inputCmd)
+	}
+	return m, inputCmd
+}
+
 // handleInsightsKeys handles keyboard input when insights panel is focused
 func (m *Model) handleInsightsKeys(msg tea.KeyMsg) *Model {
 	switch msg.String() {
@@ -5976,6 +6149,10 @@ func (m *Model) View() string {
 		body = m.repoPicker.View()
 	} else if m.showLabelPicker {
 		body = m.labelPicker.View()
+	} else if m.showAssigneePicker {
+		body = m.assigneePicker.View()
+	} else if m.showTypePicker {
+		body = m.typePicker.View()
 	} else if m.showHelp {
 		body = m.renderHelpOverlay()
 	} else if m.showTutorial {
@@ -7028,6 +7205,20 @@ func (m *Model) renderFooter() string {
 				filterIcon = "🔍"
 			}
 		}
+
+		// Assignee/type filters compose with the status/label/recipe filter
+		// above rather than replacing it, so append them to the badge text.
+		var extras []string
+		if m.assigneeFilter != "" {
+			extras = append(extras, "@"+m.assigneeFilter)
+		}
+		if m.typeFilter != "" {
+			extras = append(extras, strings.ToUpper(m.typeFilter))
+		}
+		if len(extras) > 0 {
+			filterTxt = filterTxt + " · " + strings.Join(extras, " · ")
+			filterIcon = "🔍"
+		}
 	}
 
 	filterBadge := lipgloss.NewStyle().
@@ -7090,10 +7281,17 @@ func (m *Model) renderFooter() string {
 		} else {
 			// Normal board mode - show navigation hints with filter indicator (bv-naov)
 			filterInfo := ""
-			if m.currentFilter != "all" && m.currentFilter != "" {
+			if (m.currentFilter != "all" && m.currentFilter != "") || m.assigneeFilter != "" || m.typeFilter != "" {
 				shown := m.board.TotalCount()
 				total := len(m.issues)
-				filterInfo = fmt.Sprintf("[%s:%d/%d] ", m.currentFilter, shown, total)
+				label := m.currentFilter
+				if m.assigneeFilter != "" {
+					label += "+@" + m.assigneeFilter
+				}
+				if m.typeFilter != "" {
+					label += "+" + m.typeFilter
+				}
+				filterInfo = fmt.Sprintf("[%s:%d/%d] ", label, shown, total)
 			}
 			labelHint = lipgloss.NewStyle().
 				Foreground(ColorFooterHint).
@@ -7444,7 +7642,7 @@ func (m *Model) renderFooter() string {
 		keyHints = append(keyHints, keyStyle.Render("j/k")+" nav", keyStyle.Render("⏎")+" apply", keyStyle.Render("esc")+" cancel")
 	} else if m.showRepoPicker {
 		keyHints = append(keyHints, keyStyle.Render("j/k")+" nav", keyStyle.Render("space")+" toggle", keyStyle.Render("⏎")+" apply", keyStyle.Render("esc")+" cancel")
-	} else if m.showLabelPicker {
+	} else if m.showLabelPicker || m.showAssigneePicker || m.showTypePicker {
 		keyHints = append(keyHints, "type to filter", keyStyle.Render("j/k")+" nav", keyStyle.Render("⏎")+" apply", keyStyle.Render("esc")+" cancel")
 	} else if m.focused == focusInsights {
 		keyHints = append(keyHints, keyStyle.Render("h/l")+" panels", keyStyle.Render("e")+" explain", keyStyle.Render("⏎")+" jump", keyStyle.Render("?")+" help")
@@ -7632,6 +7830,10 @@ func (m *Model) hasActiveFilters() bool {
 	if m.currentFilter != "all" {
 		return true
 	}
+	// Check assignee/type filters (compose with the filter above)
+	if m.assigneeFilter != "" || m.typeFilter != "" {
+		return true
+	}
 	// Check if fuzzy search filter is active
 	if m.list.FilterState() == list.Filtering || m.list.FilterState() == list.FilterApplied {
 		return true
@@ -7642,6 +7844,8 @@ func (m *Model) hasActiveFilters() bool {
 // clearAllFilters resets all filters to their default state
 func (m *Model) clearAllFilters() {
 	m.currentFilter = "all"
+	m.assigneeFilter = ""
+	m.typeFilter = ""
 	m.setActiveRecipe(nil) // Clear any active recipe filter
 	// Reset the fuzzy search filter by resetting the filter state
 	m.list.ResetFilter()
@@ -7664,6 +7868,28 @@ func (m *Model) matchesCurrentFilter(issue model.Issue) bool {
 		}
 	}
 
+	if !m.matchesStatusOrLabelFilter(issue) {
+		return false
+	}
+
+	// Assignee/type compose with the status/label filter above (AND) rather
+	// than replacing it, so e.g. "open" + assignee "alice" narrows to alice's
+	// open issues instead of one filter clobbering the other.
+	if m.assigneeFilter != "" && issue.Assignee != m.assigneeFilter {
+		return false
+	}
+	if m.typeFilter != "" && string(issue.IssueType) != m.typeFilter {
+		return false
+	}
+	return true
+}
+
+// matchesStatusOrLabelFilter evaluates just the currentFilter axis (status:
+// all/open/closed/ready, or label:X/recipe:X). Split out so the background
+// snapshot fast-path in Update() can reuse the exact same status/label logic
+// alongside its own workspace-repo handling (see the Phase2/snapshot refresh
+// branch), without duplicating this switch a second time.
+func (m *Model) matchesStatusOrLabelFilter(issue model.Issue) bool {
 	switch m.currentFilter {
 	case "all":
 		return true
@@ -8374,6 +8600,7 @@ func (m *Model) handleLeftClick(x, y int) *Model {
 		m.showUpdateModal || m.showLabelHealthDetail || m.showLabelGraphAnalysis ||
 		m.showLabelDrilldown || m.showAlertsPanel || m.showTimeTravelPrompt ||
 		m.showRecipePicker || m.showRepoPicker || m.showLabelPicker ||
+		m.showAssigneePicker || m.showTypePicker ||
 		m.showHelp || m.showTutorial {
 		return m
 	}
@@ -8724,6 +8951,22 @@ func (m *Model) SetFilter(f string) {
 	m.applyFilter()
 }
 
+// SetAssigneeFilter sets the assignee filter, which composes with (rather
+// than replaces) the status/label filter set via SetFilter. Pass "" to clear
+// it. (exposed for testing)
+func (m *Model) SetAssigneeFilter(assignee string) {
+	m.assigneeFilter = assignee
+	m.applyFilter()
+}
+
+// SetTypeFilter sets the issue type filter, which composes with (rather than
+// replaces) the status/label filter set via SetFilter. Pass "" to clear it.
+// (exposed for testing)
+func (m *Model) SetTypeFilter(issueType string) {
+	m.typeFilter = issueType
+	m.applyFilter()
+}
+
 // FilteredIssues returns the currently visible issues (exposed for testing)
 func (m Model) FilteredIssues() []model.Issue {
 	items := m.list.Items()
@@ -8935,6 +9178,10 @@ func (f focus) String() string {
 		return "attention"
 	case focusLabelPicker:
 		return "label_picker"
+	case focusAssigneePicker:
+		return "assignee_picker"
+	case focusTypePicker:
+		return "type_picker"
 	case focusSprint:
 		return "sprint"
 	case focusAgentPrompt:

--- a/pkg/ui/model_test.go
+++ b/pkg/ui/model_test.go
@@ -94,6 +94,120 @@ func TestModelFiltering(t *testing.T) {
 	}
 }
 
+func TestModelFilteringByAssigneeAndType(t *testing.T) {
+	issues := []model.Issue{
+		{ID: "1", Title: "Bug for alice", Status: model.StatusOpen, IssueType: model.TypeBug, Assignee: "alice"},
+		{ID: "2", Title: "Feature for bob", Status: model.StatusOpen, IssueType: model.TypeFeature, Assignee: "bob"},
+		{ID: "3", Title: "Another bug for alice", Status: model.StatusClosed, IssueType: model.TypeBug, Assignee: "alice"},
+		{ID: "4", Title: "Unassigned task", Status: model.StatusOpen, IssueType: model.TypeTask, Assignee: ""},
+	}
+
+	m := ui.NewModel(issues, nil, "")
+
+	m.SetAssigneeFilter("alice")
+	aliceIssues := m.FilteredIssues()
+	if len(aliceIssues) != 2 {
+		t.Fatalf("Expected 2 issues for assignee 'alice', got %d", len(aliceIssues))
+	}
+	for _, issue := range aliceIssues {
+		if issue.Assignee != "alice" {
+			t.Errorf("Expected only alice's issues, got assignee %q", issue.Assignee)
+		}
+	}
+
+	m.SetAssigneeFilter("bob")
+	bobIssues := m.FilteredIssues()
+	if len(bobIssues) != 1 || bobIssues[0].ID != "2" {
+		t.Errorf("Expected 1 issue (ID 2) for assignee 'bob', got %#v", bobIssues)
+	}
+
+	m.SetAssigneeFilter("nobody")
+	if len(m.FilteredIssues()) != 0 {
+		t.Errorf("Expected 0 issues for unknown assignee, got %d", len(m.FilteredIssues()))
+	}
+	m.SetAssigneeFilter("") // clear before moving on to type-only checks
+
+	m.SetTypeFilter("bug")
+	bugIssues := m.FilteredIssues()
+	if len(bugIssues) != 2 {
+		t.Fatalf("Expected 2 issues for type 'bug', got %d", len(bugIssues))
+	}
+	for _, issue := range bugIssues {
+		if issue.IssueType != model.TypeBug {
+			t.Errorf("Expected only bug issues, got type %q", issue.IssueType)
+		}
+	}
+
+	m.SetTypeFilter("task")
+	taskIssues := m.FilteredIssues()
+	if len(taskIssues) != 1 || taskIssues[0].ID != "4" {
+		t.Errorf("Expected 1 issue (ID 4) for type 'task', got %#v", taskIssues)
+	}
+	m.SetTypeFilter("")
+
+	m.SetFilter("all")
+	if len(m.FilteredIssues()) != 4 {
+		t.Errorf("Expected 4 issues for 'all' after clearing filter, got %d", len(m.FilteredIssues()))
+	}
+}
+
+// TestModelFilteringComposesStatusWithAssigneeAndType guards against the
+// regression where selecting an assignee or type filter would silently
+// clobber an active open/closed/ready status filter instead of narrowing it
+// further (they should AND together, not replace one another).
+func TestModelFilteringComposesStatusWithAssigneeAndType(t *testing.T) {
+	issues := []model.Issue{
+		{ID: "1", Title: "Open bug for alice", Status: model.StatusOpen, IssueType: model.TypeBug, Assignee: "alice"},
+		{ID: "2", Title: "Closed bug for alice", Status: model.StatusClosed, IssueType: model.TypeBug, Assignee: "alice"},
+		{ID: "3", Title: "Open feature for alice", Status: model.StatusOpen, IssueType: model.TypeFeature, Assignee: "alice"},
+		{ID: "4", Title: "Open bug for bob", Status: model.StatusOpen, IssueType: model.TypeBug, Assignee: "bob"},
+	}
+
+	m := ui.NewModel(issues, nil, "")
+
+	// Status filter alone: 3 open issues (1, 3, 4).
+	m.SetFilter("open")
+	if got := len(m.FilteredIssues()); got != 3 {
+		t.Fatalf("Expected 3 open issues, got %d", got)
+	}
+
+	// Adding an assignee filter on top of "open" should narrow, not replace:
+	// only alice's open issues (1, 3).
+	m.SetAssigneeFilter("alice")
+	openAlice := m.FilteredIssues()
+	if len(openAlice) != 2 {
+		t.Fatalf("Expected 2 issues for open+assignee:alice, got %d: %#v", len(openAlice), openAlice)
+	}
+	for _, issue := range openAlice {
+		if issue.Assignee != "alice" || issue.Status != model.StatusOpen {
+			t.Errorf("Expected only alice's open issues, got %+v", issue)
+		}
+	}
+
+	// Further narrowing by type on top of open+assignee: only issue 1.
+	m.SetTypeFilter("bug")
+	openAliceBug := m.FilteredIssues()
+	if len(openAliceBug) != 1 || openAliceBug[0].ID != "1" {
+		t.Fatalf("Expected 1 issue (ID 1) for open+assignee:alice+type:bug, got %#v", openAliceBug)
+	}
+
+	// Switching the status filter to "closed" while assignee/type filters
+	// stay active should now show alice's closed bug (ID 2) instead.
+	m.SetFilter("closed")
+	closedAliceBug := m.FilteredIssues()
+	if len(closedAliceBug) != 1 || closedAliceBug[0].ID != "2" {
+		t.Fatalf("Expected 1 issue (ID 2) for closed+assignee:alice+type:bug, got %#v", closedAliceBug)
+	}
+
+	// Clearing all filters restores every issue.
+	m.SetFilter("all")
+	m.SetAssigneeFilter("")
+	m.SetTypeFilter("")
+	if got := len(m.FilteredIssues()); got != 4 {
+		t.Fatalf("Expected 4 issues after clearing all filters, got %d", got)
+	}
+}
+
 func TestFormatTimeRel(t *testing.T) {
 	now := time.Now()
 	tests := []struct {

--- a/pkg/ui/tutorial_content.go
+++ b/pkg/ui/tutorial_content.go
@@ -346,7 +346,11 @@ func structuredTutorialPages() []StructuredTutorialPage {
 					{Key: "c", Desc: "Closed issues only"},
 					{Key: "r", Desc: "Ready (no blockers)"},
 					{Key: "a", Desc: "All (reset filter)"},
+					{Key: "A", Desc: "Filter by assignee (picker)"},
+					{Key: "I", Desc: "Filter by issue type (picker)"},
 				}},
+				Spacer{Lines: 1},
+				Tip{Text: "Assignee/type filters combine with o/c/r instead of replacing them"},
 				Spacer{Lines: 1},
 				Section{Title: "Searching"},
 				KeyTable{Bindings: []KeyHint{


### PR DESCRIPTION
## Summary

- Adds an assignee quick-filter (`A`) and issue-type quick-filter (`I`) to the main list view, following the existing label-picker pattern (fuzzy-search overlay, generalized from `label_picker.go` and reused for both).
- Both filters **compose** with the existing status/label filter (`o`/`c`/`r`/`a`/`l`) instead of replacing it — e.g. `o` then `A` → alice narrows to alice's open issues. This required consolidating a duplicated, hand-rolled copy of the status/label matching logic in the background snapshot-refresh path (`matchesStatusOrLabelFilter`), which otherwise would have silently dropped the new filters on the next data refresh.
- Wired into the filter status badge, footer hints, click-guard, embedded text-input session tracking, context help, tutorial content, and the shortcuts-sidebar keybinding docs. README's "Instant Filtering" bullet and Keyboard Control Map updated to match.

## Unrelated pre-existing fixes (needed just to compile)

Two commits fix build breaks on `main` that predate this branch and are unrelated to the filter feature:
- `pkg/correlation`: a prior refactor moved degree-counting into a method (`recomputeNodeDegrees`) that was never added, leaving the package non-compiling.
- `pkg/ui`: `handleHistoryKeys` referenced an undeclared `cmd`, which — beyond not compiling — silently dropped the async clipboard-copy command in History view.

## Known pre-existing failures NOT touched by this PR

CI may still show red on jobs unrelated to this change:
- `pkg/correlation/network_test.go` (`TestSplitEdgeKey`) references a helper a prior refactor already removed in favor of a typed `networkEdgeKey` — the test itself is now dead and doesn't compile. Left alone per repo convention of not deleting test code without explicit sign-off.
- `cmd/bv`: one failing test (`TestAgentIntentArgRewrite/...`), unrelated to filtering.
- `pkg/ui`: 7 pre-existing failing tests, all in History view (search mode, file-tree, confidence cycling, cass-modal copy).
- `pkg/export` / `tests/e2e`: several failing tests (wizard/deploy flow).

Confirmed via isolated builds (reverting to a pre-branch baseline + only the minimal build fixes) that every one of the above fails identically with or without this branch's feature commits.

## Test plan
- [x] `go build ./...`
- [x] `go test ./pkg/ui/...` — all new tests pass; only the pre-existing unrelated failures listed above remain
- [x] New tests cover: assignee/type filter matching, extraction helpers, full key-dispatch flows (open picker → type query → `q` doesn't leak to quit → enter applies filter), and the exact status+assignee/type composition regression
- [x] `gofmt -l` clean on all touched files
- [ ] CI (expected red on the unrelated pre-existing failures listed above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)